### PR TITLE
Fix #49 and allow external dialect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: frictionless
 Title: Read and Write Frictionless Data Packages
-Version: 0.3.0.9000
+Version: 0.4.0.9000
 Authors@R: c(
     person("Peter", "Desmet", , "peter.desmet@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8442-8025")),

--- a/R/get_schema.R
+++ b/R/get_schema.R
@@ -32,11 +32,7 @@ get_schema <- function(resource_name, package) {
   )
 
   # Get schema
-  schema <- resource$schema
-  if (is.character(schema)) {
-    schema <- check_path(schema, directory = package$directory, unsafe = FALSE)
-    schema <- jsonlite::fromJSON(schema, simplifyDataFrame = FALSE)
-  }
+  schema <- read_json(resource$schema, package$directory)
 
   # Check schema has fields
   fields <- schema$fields

--- a/R/read_resource.R
+++ b/R/read_resource.R
@@ -53,7 +53,8 @@
 #'
 #' `dialect` properties are
 #' [required](https://specs.frictionlessdata.io/csv-dialect/#specification) if
-#' the resource file(s) deviate from the default CSV settings (see below). Only
+#' the resource file(s) deviate from the default CSV settings (see below). It
+#' can either be a JSON object or a URL or path referencing a JSON object. Only
 #' deviating properties need to be specified, e.g. a tab delimited file without
 #' a header row needs:
 #' ```json
@@ -302,7 +303,7 @@ read_resource <- function(resource_name, package) {
   names(col_types) <- col_names
 
   # Select CSV dialect, see https://specs.frictionlessdata.io/csv-dialect/
-  dialect <- resource$dialect # Can be NULL
+  dialect <- read_json(resource$dialect, package$directory) # Can be NULL
 
   # Read data
   dataframes <- list()

--- a/R/utils.R
+++ b/R/utils.R
@@ -89,3 +89,19 @@ check_path <- function(path, directory = NULL, unsafe = TRUE) {
   }
   return(path)
 }
+
+#' Read JSON at path or URL
+#'
+#' Reads JSON when provided property is a character (path or URL), otherwise
+#' returns property.
+#' @param x Any object or a path or URL to a file.
+#' @param directory Directory to prepend to path.
+#' @return `x` (unchanged) or loaded JSON at path or URL.
+#' @noRd
+read_json <- function(x, directory) {
+  if (is.character(x)) {
+    x <- check_path(x, directory = directory, unsafe = FALSE)
+    x <- jsonlite::fromJSON(x, simplifyDataFrame = FALSE)
+  }
+  return(x)
+}

--- a/man/read_resource.Rd
+++ b/man/read_resource.Rd
@@ -69,7 +69,8 @@ The returned data frame will always be UTF-8.
 
 \code{dialect} properties are
 \href{https://specs.frictionlessdata.io/csv-dialect/#specification}{required} if
-the resource file(s) deviate from the default CSV settings (see below). Only
+the resource file(s) deviate from the default CSV settings (see below). It
+can either be a JSON object or a URL or path referencing a JSON object. Only
 deviating properties need to be specified, e.g. a tab delimited file without
 a header row needs:\if{html}{\out{<div class="sourceCode json">}}\preformatted{"dialect": \{"delimiter": "\\t", "header": "false"\}
 }\if{html}{\out{</div>}}

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -136,6 +136,24 @@ test_that("read_resource() can read local and remote schemas", {
   expect_identical(resource, read_resource("deployments", pkg_remote_schema))
 })
 
+test_that("read_resource() can read local and remote CSV dialect", {
+  pkg <- suppressMessages(read_package(
+    system.file("extdata", "datapackage.json", package = "frictionless"))
+  )
+  resource <- read_resource("deployments", pkg)
+
+  pkg_local_dialect <- pkg
+  pkg_local_dialect$directory <- "." # Use "./tests/testthat/data" outside test
+  pkg_local_dialect$resources[[1]]$dialect <- "data/dialect.json"
+  # Using a remote path, otherwise schema and path need to share same directory
+  pkg_local_dialect$resources[[1]]$path <- "https://github.com/frictionlessdata/frictionless-r/raw/main/inst/extdata/deployments.csv"
+  expect_identical(resource, read_resource("deployments", pkg_local_dialect))
+
+  pkg_remote_dialect <- pkg
+  pkg_remote_dialect$resources[[1]]$dialect <- "https://github.com/frictionlessdata/frictionless-r/raw/main/tests/testthat/data/dialect.json"
+  expect_identical(resource, read_resource("deployments", pkg_remote_dialect))
+})
+
 test_that("read_resource() understands CSV dialect", {
   pkg <- suppressMessages(read_package(
     system.file("extdata", "datapackage.json", package = "frictionless"))


### PR DESCRIPTION
Copies functionality that was already implemented to get external schema to helper function `read_json()` that is now used for schemas and dialects.