### PR TITLE
Fix #79: create_schema() will interpret columns with all NA as string

### DIFF
--- a/R/create_schema.R
+++ b/R/create_schema.R
@@ -79,7 +79,7 @@ create_schema <- function(data) {
   # Columns with all NA are considered logical by R (and read_delim)
   # Set those to character, since string is a better default for Table Schema
   data_as_list <- lapply(data, function(x) {
-    if (all(is.na(x))) {
+    if (is.logical(x) & all(is.na(x))) {
       as.character(x)
     } else {
       x

--- a/R/create_schema.R
+++ b/R/create_schema.R
@@ -76,6 +76,16 @@ create_schema <- function(data) {
     )
   )
 
+  # Columns with all NA are considered logical by R (and read_delim)
+  # Set those to character, since string is a better default for Table Schema
+  data_as_list <- lapply(data, function(x) {
+    if (all(is.na(x))) {
+      as.character(x)
+    } else {
+      x
+    }
+  })
+
   # Create fields (a list of lists)
   fields <- purrr::imap(data_as_list, function(x, name) {
     # Name

--- a/R/create_schema.R
+++ b/R/create_schema.R
@@ -77,38 +77,37 @@ create_schema <- function(data) {
   )
 
   # Create fields (a list of lists)
-  fields <-
-    purrr::imap(data, function(x, name) {
-      # Name
-      name <- ifelse(is.na(name), "", name)
+  fields <- purrr::imap(data_as_list, function(x, name) {
+    # Name
+    name <- ifelse(is.na(name), "", name)
 
-      # Type
-      type <- paste(class(x), collapse = ",") # When data type is a vector
-      type <- dplyr::recode(type,
-        "character" = "string",
-        "Date" = "date",
-        "difftime" = "number",
-        "factor" = "string",
-        "hms,difftime" = "time", # Data read using col_time()
-        "integer" = "integer",
-        "logical" = "boolean",
-        "numeric" = "number", # Includes double
-        "POSIXct,POSIXt" = "datetime", # Includes POSIXlt,POSIXt
-        .default = "any"
+    # Type
+    type <- paste(class(x), collapse = ",") # When data type is a vector
+    type <- dplyr::recode(type,
+      "character" = "string",
+      "Date" = "date",
+      "difftime" = "number",
+      "factor" = "string",
+      "hms,difftime" = "time", # Data read using col_time()
+      "integer" = "integer",
+      "logical" = "boolean",
+      "numeric" = "number", # Includes double
+      "POSIXct,POSIXt" = "datetime", # Includes POSIXlt,POSIXt
+      .default = "any"
+    )
+
+    # Enumeration
+    enum <- levels(x)
+
+    # Create field list object
+    list(
+      name = name,
+      type = type,
+      constraints = list(
+        enum = enum
       )
-
-      # Enumeration
-      enum <- levels(x)
-
-      # Create field list object
-      list(
-        name = name,
-        type = type,
-        constraints = list(
-          enum = enum
-        )
-      )
-    })
+    )
+  })
 
   # Create schema
   schema <- list(

--- a/tests/testthat/test-create_schema.R
+++ b/tests/testthat/test-create_schema.R
@@ -127,9 +127,29 @@ test_that("create_schema() translates coltypes into field types", {
 })
 
 test_that("create_schema() will set columns containing all NA to string", {
-  df <- data.frame(col_1 = NA, col_2 = c(NA, 1), col_3 = c(TRUE, NA))
+  df <- data.frame(
+    na_all = NA,
+    na_one = c(NA, 1),
+    logical = c(TRUE, NA),
+    na_integer = NA_integer_,
+    na_real = NA_real_,
+    na_complex = NA_complex_,
+    na_character = NA_character_
+  )
   schema <- create_schema(df)
-  expect_identical(schema$fields[[1]]$type, "string") # Was logical
-  expect_identical(schema$fields[[2]]$type, "number") # Keep double
-  expect_identical(schema$fields[[3]]$type, "boolean") # Keep logical
+  types <- purrr::map(schema$fields, ~ .x$type)
+  types <- setNames(types, purrr::map_chr(schema$fields, ~ .x$name))
+
+  expect_identical(
+    types,
+    list(
+      na_all = "string",
+      na_one = "number",
+      logical = "boolean",
+      na_integer = "integer",
+      na_real = "number",
+      na_complex = "any",
+      na_character = "string"
+    )
+  )
 })

--- a/tests/testthat/test-create_schema.R
+++ b/tests/testthat/test-create_schema.R
@@ -125,3 +125,11 @@ test_that("create_schema() translates coltypes into field types", {
     )
   )
 })
+
+test_that("create_schema() will set columns containing all NA to string", {
+  df <- data.frame(col_1 = NA, col_2 = c(NA, 1), col_3 = c(TRUE, NA))
+  schema <- create_schema(df)
+  expect_identical(schema$fields[[1]]$type, "string") # Was logical
+  expect_identical(schema$fields[[2]]$type, "number") # Keep double
+  expect_identical(schema$fields[[3]]$type, "boolean") # Keep logical
+})


### PR DESCRIPTION
This is not only done for data frames as result of `read_delim()` in `add_resource()`, but all data frames, since it is default R behaviour to set columns with all `NA` as logical.

The function `create_schema()` now handles these. Note that the data frame itself is not altered, only the field type in the resulting `schema` will be set to `string` rather than `boolean` for these columns.

I used `lapply()` with anonymous function. Alternative would be dplyr functions:

```R
dplyr::mutate(df, dplyr::across(tidyselect::where(all(is.na)), as.character))
```

but that requires tidyselect as dependency and it will raise an error for col names that are `NA` (allowed, there is a test for that).