### PR TITLE
Set profile to "tabular-data-package" when creating package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,19 +2,21 @@
 
 - `add_resource()` now supports adding CSV file(s) directly as a resource.
   This skips reading/handling by R and gives users control over `path` (#74).
-- `write_package()` now downloads CSV files(s) from a remotely read package
-  (like `example_package`) rather than skipping them.
+- CSV files in a remotely read package (like `example_package`) are now
+  downloaded when writing with `write_package()`, rather than being skipped.
   This is more consistent with locally read packages.
   The behaviour for resources with a `path` containing URLs (only) and resources 
   with `data` remains the same (no files are written).
   The write behaviour is better explained in the documentation (#77).
 - `write_package()` now silently returns the output rather than input `package`.
-- `add_resource()`/`create_schema()`'s `df` parameter is renamed to `data`.
+- `create_package()` will set `"profile" = "tabular-data-package"` since 
+  packages created by frictionless meet those requirements (#81).
 - `create_schema()` interprets empty columns as `string` not `boolean` (#79).
+- `add_resource()`/`create_schema()`'s `df` parameter is renamed to `data`.
 - `example_package`'s `observations` resource now has URLs as `path` to serve 
   as an example for that.
 
 # frictionless 0.9.0
 
 - Add vignette with overview of functionality (#60).
-- Prepare pkg for rOpenSci submission.
+- Prepare frictionless for rOpenSci submission.

--- a/R/create_package.R
+++ b/R/create_package.R
@@ -2,8 +2,11 @@
 #'
 #' Initiates a list object describing a [Data
 #' Package](https://specs.frictionlessdata.io/data-package/).
-#' This empty Data Package can then be extended with metadata and resources (see
+#' This empty Data Package can be extended with metadata and resources (see
 #' [add_resource()]).
+#' Added resources will make the Data Package meet [Tabular Data
+#' Package](https://specs.frictionlessdata.io/tabular-data-package/)
+#' requirements, so `profile` is set to `tabular-data-package`.
 #'
 #' @return List object describing a Data Package.
 #' @family create functions
@@ -14,6 +17,7 @@
 #' str(package)
 create_package <- function() {
   descriptor <- list(
+    profile = "tabular-data-package",
     resources = list(),
     resource_names = vector(mode = "character"),
     directory = "." # Current directory

--- a/man/create_package.Rd
+++ b/man/create_package.Rd
@@ -11,8 +11,10 @@ List object describing a Data Package.
 }
 \description{
 Initiates a list object describing a \href{https://specs.frictionlessdata.io/data-package/}{Data Package}.
-This empty Data Package can then be extended with metadata and resources (see
+This empty Data Package can be extended with metadata and resources (see
 \code{\link[=add_resource]{add_resource()}}).
+Added resources will make the Data Package meet \href{https://specs.frictionlessdata.io/tabular-data-package/}{Tabular Data Package}
+requirements, so \code{profile} is set to \code{tabular-data-package}.
 }
 \examples{
 # Create a Data Package

--- a/tests/testthat/test-create_package.R
+++ b/tests/testthat/test-create_package.R
@@ -1,3 +1,8 @@
 test_that("create_package() returns a valid Data Package", {
   expect_true(check_package(create_package()))
 })
+
+test_that("create_package() sets profile to 'tabular-data-package'", {
+  p <- create_package()
+  expect_identical(p$profile, "tabular-data-package")
+})


### PR DESCRIPTION
Added resources will make the Data Package meet [Tabular Data Package](https://specs.frictionlessdata.io/tabular-data-package/) requirements, so `profile` is set to `tabular-data-package`. The property is not a requirement for `check_package()` (as incoming packages might not have it).

Setting `profile` makes for stronger validation for downstream users.