### PR TITLE
Support descriptor, schema, dialect in YAML, fix #66

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,8 @@ Imports:
     purrr,
     readr (>= 2.1.0),
     stringr,
-    utils
+    utils,
+    yaml
 Suggests:
     knitr,
     hms,

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 - `create_package()` will set `"profile" = "tabular-data-package"` since 
   packages created by frictionless meet those requirements (#81).
 - `create_schema()` interprets empty columns as `string` not `boolean` (#79).
+- `read_package()` can now read from a `datapackage.yaml` file.
+- `read_resource()` now accepts YAML Table Schemas and CSV dialects.
 - `add_resource()`/`create_schema()`'s `df` parameter is renamed to `data`.
 - `example_package`'s `observations` resource now has URLs as `path` to serve 
   as an example for that.

--- a/R/add_resource.R
+++ b/R/add_resource.R
@@ -89,12 +89,10 @@ add_resource <- function(package, resource_name, data, schema = NULL,
   if (is.data.frame(data)) {
     df <- data
   } else {
-    # Check existence of files (no further checks)
-    paths <- purrr::map_chr(
-      data, ~ check_path(.x, directory = NULL, unsafe = TRUE)
-    )
+    # Check existence of files (no further checks) and read last file
+    paths <- purrr::map_chr(data, ~ check_path(.x, safe = FALSE))
     df <- readr::read_delim(
-      file = paths[length(paths)], # Last file
+      file = paths[length(paths)],
       delim = delim,
       show_col_types = FALSE,
     )

--- a/R/get_resource.R
+++ b/R/get_resource.R
@@ -52,7 +52,7 @@ get_resource <- function(package, resource_name) {
     # unless those paths were willingly added by user in add_resource()
     if (replace_null(attributes(resource)$path, "") != "added") {
       resource$path <- purrr::map_chr(
-        resource$path, ~ check_path(.x, package$directory, unsafe = FALSE)
+        resource$path, ~ check_path(.x, package$directory, safe = TRUE)
       )
     }
   } else if (is.data.frame(resource$data)) {

--- a/R/get_schema.R
+++ b/R/get_schema.R
@@ -37,7 +37,7 @@ get_schema <- function(package, resource_name) {
     !is.null(resource$schema),
     msg = glue::glue("Resource `{resource_name}` must have property `schema`.")
   )
-  schema <- read_json(resource$schema, package$directory)
+  schema <- read_json(resource$schema, package$directory, safe = TRUE)
 
   # Check schema
   check_schema(schema)

--- a/R/get_schema.R
+++ b/R/get_schema.R
@@ -37,7 +37,7 @@ get_schema <- function(package, resource_name) {
     !is.null(resource$schema),
     msg = glue::glue("Resource `{resource_name}` must have property `schema`.")
   )
-  schema <- read_json(resource$schema, package$directory, safe = TRUE)
+  schema <- read_descriptor(resource$schema, package$directory, safe = TRUE)
 
   # Check schema
   check_schema(schema)

--- a/R/read_package.R
+++ b/R/read_package.R
@@ -23,8 +23,11 @@
 #' package$resource_names
 read_package <- function(file = "datapackage.json") {
   # Read file
-  file <- check_path(file, safe = FALSE)
-  descriptor <- jsonlite::fromJSON(file, simplifyDataFrame = FALSE)
+  assertthat::assert_that(
+    is.character(file),
+    msg = "`file` must be a path or URL to a `datapackage.json` file."
+  )
+  descriptor <- read_descriptor(file, safe = FALSE)
 
   # Check resources
   # https://specs.frictionlessdata.io/data-package/#metadata

--- a/R/read_package.R
+++ b/R/read_package.R
@@ -23,7 +23,7 @@
 #' package$resource_names
 read_package <- function(file = "datapackage.json") {
   # Read file
-  file <- check_path(file)
+  file <- check_path(file, safe = FALSE)
   descriptor <- jsonlite::fromJSON(file, simplifyDataFrame = FALSE)
 
   # Check resources

--- a/R/read_resource.R
+++ b/R/read_resource.R
@@ -312,7 +312,8 @@ read_resource <- function(package, resource_name) {
   names(col_types) <- col_names
 
   # Select CSV dialect, see https://specs.frictionlessdata.io/csv-dialect/
-  dialect <- read_json(resource$dialect, package$directory) # Can be NULL
+  # Note that dialect can be NULL
+  dialect <- read_json(resource$dialect, package$directory, safe = TRUE)
 
   # Read data directly
   if (resource$read_from == "df") {

--- a/R/read_resource.R
+++ b/R/read_resource.R
@@ -313,7 +313,7 @@ read_resource <- function(package, resource_name) {
 
   # Select CSV dialect, see https://specs.frictionlessdata.io/csv-dialect/
   # Note that dialect can be NULL
-  dialect <- read_json(resource$dialect, package$directory, safe = TRUE)
+  dialect <- read_descriptor(resource$dialect, package$directory, safe = TRUE)
 
   # Read data directly
   if (resource$read_from == "df") {

--- a/R/utils.R
+++ b/R/utils.R
@@ -69,20 +69,21 @@ clean_list <- function(x, fun = is.null, recursive = FALSE) {
 #'
 #' @param path Path or URL to a file.
 #' @param directory Directory to prepend to path.
-#' @param unsafe Allow `path` to be an unsafe absolute or relative parent path.
+#' @param safe Require `path` to be safe, i.e. no absolute or relative parent
+#'   paths.
 #' @return Absolute path or URL.
 #' @family helper functions
 #' @noRd
-check_path <- function(path, directory = NULL, unsafe = TRUE) {
+check_path <- function(path, directory = NULL, safe = FALSE) {
   # Check that (non-URL) path is safe and prepend with directory to make
   # absolute path (both optional)
   if (!startsWith(path, "http")) {
     assertthat::assert_that(
-      unsafe | !startsWith(path, "/"),
+      !safe | !startsWith(path, "/"),
       msg = glue::glue("`{path}` is an absolute path (`/`) which is unsafe.")
     )
     assertthat::assert_that(
-      unsafe | !startsWith(path, "../"),
+      !safe | !startsWith(path, "../"),
       msg = glue::glue(
         "`{path}` is a relative parent path (`../`) which is unsafe."
       )

--- a/R/utils.R
+++ b/R/utils.R
@@ -108,19 +108,23 @@ check_path <- function(path, directory = NULL, safe = FALSE) {
   return(path)
 }
 
-#' Read JSON at path or URL
+#' Read descriptor
 #'
-#' Reads JSON when provided property is a character (path or URL), otherwise
-#' returns property.
+#' Returns descriptor `x` as is, or attempts to read JSON/YAML from path or URL.
 #'
 #' @inheritParams check_path
-#' @return `x` (unchanged) or loaded JSON at path or URL.
+#' @return `x` (unchanged) or loaded JSON/YAML at path or URL.
 #' @family helper functions
 #' @noRd
-read_json <- function(x, directory, safe = FALSE) {
+read_descriptor <- function(x, directory = NULL, safe = FALSE) {
   if (is.character(x)) {
     x <- check_path(x, directory = directory, safe = safe)
-    x <- jsonlite::fromJSON(x, simplifyDataFrame = FALSE)
+    if (grepl(".yaml$", x) | grepl(".yml$", x)) {
+      x <- yaml::yaml.load_file(x)
+    } else {
+      # Default to jsonlite: better error messages for non .json files
+      x <- jsonlite::fromJSON(x, simplifyDataFrame = FALSE)
+    }
   }
   return(x)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -113,14 +113,13 @@ check_path <- function(path, directory = NULL, safe = FALSE) {
 #' Reads JSON when provided property is a character (path or URL), otherwise
 #' returns property.
 #'
-#' @param x Any object or a path or URL to a file.
-#' @param directory Directory to prepend to path.
+#' @inheritParams check_path
 #' @return `x` (unchanged) or loaded JSON at path or URL.
 #' @family helper functions
 #' @noRd
-read_json <- function(x, directory) {
+read_json <- function(x, directory, safe = FALSE) {
   if (is.character(x)) {
-    x <- check_path(x, directory = directory, unsafe = FALSE)
+    x <- check_path(x, directory = directory, safe = safe)
     x <- jsonlite::fromJSON(x, simplifyDataFrame = FALSE)
   }
   return(x)

--- a/tests/testthat/data/deployments_schema.yaml
+++ b/tests/testthat/data/deployments_schema.yaml
@@ -1,0 +1,29 @@
+fields:
+- name: deployment_id
+  type: string
+  constraints:
+    required: true
+    unique: true
+- name: longitude
+  type: number
+  constraints:
+    required: true
+    minimum: -180
+    maximum: 180
+- name: latitude
+  constraints:
+    required: true
+- name: start
+  type: date
+  format: "%x"
+  constraints:
+    required: true
+- name: comments
+  type: string
+  constraints:
+    required: false
+missingValues:
+- ''
+- NA
+- NaN
+primaryKey: deployment_id

--- a/tests/testthat/data/dialect.yaml
+++ b/tests/testthat/data/dialect.yaml
@@ -1,0 +1,7 @@
+delimiter: ","
+lineTerminator: ","
+quoteChar: "\""
+doubleQuote: true
+skipInitialSpace: false
+header: true
+caseSensitiveHeader: false

--- a/tests/testthat/data/valid_minimal.yml
+++ b/tests/testthat/data/valid_minimal.yml
@@ -1,0 +1,4 @@
+resources:
+- name: deployments
+- name: observations
+- name: media

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -56,6 +56,13 @@ test_that("read_package() shows message about usage norms", {
 })
 
 test_that("read_package() returns error on missing file and properties", {
+  # Incorrect type
+  expect_error(
+    read_package(list()),
+    "`file` must be a path or URL to a `datapackage.json` file.",
+    fixed = TRUE
+  )
+
   # No file
   expect_error(
     read_package("nofile.json"),
@@ -104,5 +111,23 @@ test_that("read_package() returns error on missing file and properties", {
       "containing at least one resource. All resources must have a `name`."
     ),
     fixed = TRUE
+  )
+})
+
+test_that("read_package() allows descriptor at absolute or relative parent
+           path", {
+  relative_path <- "../testthat/data/valid_minimal.json"
+  expect_true(
+    check_package(suppressMessages(read_package(relative_path)))
+  )
+  absolute_path <- normalizePath("data/valid_minimal.json")
+  expect_true(
+    check_package(suppressMessages(read_package(absolute_path)))
+  )
+})
+
+test_that("read_package() allows YAML descriptor", {
+  expect_true(
+    check_package(suppressMessages(read_package("data/valid_minimal.yml")))
   )
 })

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -197,11 +197,12 @@ test_that("read_resource() can read remote files", {
   expect_identical(read_resource(p_remote_resource, "deployments"), resource)
 })
 
-test_that("read_resource() can read safe local and remote Table Schemas", {
+test_that("read_resource() can read safe local and remote Table Schema,
+           including YAML", {
   p <- example_package
   resource <- read_resource(p, "deployments")
   p$directory <- "."
-  # Using a remote path, otherwise schema and path need to share same directory
+  # Use a remote path, otherwise schema and path need to share same directory
   p$resources[[1]]$path <- file.path(
     "https://github.com/frictionlessdata/frictionless-r",
     "raw/main/inst/extdata/deployments.csv"
@@ -244,13 +245,18 @@ test_that("read_resource() can read safe local and remote Table Schemas", {
     "raw/main/tests/testthat/data/deployments_schema.json"
   )
   expect_identical(read_resource(p_remote_schema, "deployments"), resource)
+
+  # Schema is YAML
+  p_yaml_schema <- p
+  p_yaml_schema$resource[[1]]$schema <- "data/deployment_schema.yaml"
+  expect_identical(read_resource(p_yaml_schema, "deployments"), resource)
 })
 
 test_that("read_resource() can read safe local and remote CSV dialect", {
   p <- example_package
   resource <- read_resource(p, "deployments")
   p$directory <- "."
-  # Using a remote path, otherwise dialect and path need to share same directory
+  # Use a remote path, otherwise dialect and path need to share same directory
   p$resources[[1]]$path <- file.path(
     "https://github.com/frictionlessdata/frictionless-r",
     "raw/main/inst/extdata/deployments.csv"
@@ -291,6 +297,11 @@ test_that("read_resource() can read safe local and remote CSV dialect", {
     "raw/main/tests/testthat/data/dialect.json"
   )
   expect_identical(read_resource(p_remote_dialect, "deployments"), resource)
+
+  # Dialect is YAML
+  p_yaml_dialect <- p
+  p_yaml_dialect$resource[[1]]$dialect <- "data/dialect.yaml"
+  expect_identical(read_resource(p_yaml_dialect, "deployments"), resource)
 })
 
 test_that("read_resource() understands CSV dialect", {

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -130,30 +130,6 @@ test_that("read_resource() returns error on incorrect resource", {
     # no fixed = TRUE, since full returned path depends on system
   )
 
-  # Schema is absolute path
-  p_invalid$resources[[1]]$schema <- file.path(
-    "/tests/testthat/data/deployments_schema.json"
-  )
-  expect_error(
-    read_resource(p_invalid, "deployments"),
-    paste(
-      "`/tests/testthat/data/deployments_schema.json` is an absolute path",
-      "(`/`) which is unsafe."
-    ),
-    fixed = TRUE
-  )
-
-  # Schema is relative parent path
-  p_invalid$resources[[1]]$schema <- "../testthat/data/deployments_schema.json"
-  expect_error(
-    read_resource(p_invalid, "deployments"),
-    paste(
-      "`../testthat/data/deployments_schema.json` is a relative parent path",
-      "(`../`) which is unsafe."
-    ),
-    fixed = TRUE
-  )
-
   # No fields
   p_invalid$resources[[1]]$schema <- list()
   expect_error(
@@ -221,20 +197,47 @@ test_that("read_resource() can read remote files", {
   expect_identical(read_resource(p_remote_resource, "deployments"), resource)
 })
 
-test_that("read_resource() can read local and remote Table Schemas", {
+test_that("read_resource() can read safe local and remote Table Schemas", {
   p <- example_package
   resource <- read_resource(p, "deployments")
-
-  p_local_schema <- p
-  p_local_schema$directory <- "." # Use "./tests/testthat" outside test
-  p_local_schema$resources[[1]]$schema <- "data/deployments_schema.json"
+  p$directory <- "."
   # Using a remote path, otherwise schema and path need to share same directory
-  p_local_schema$resources[[1]]$path <- file.path(
+  p$resources[[1]]$path <- file.path(
     "https://github.com/frictionlessdata/frictionless-r",
     "raw/main/inst/extdata/deployments.csv"
   )
+
+  # Schema is absolute path
+  p_unsafe <- p
+  p_unsafe$resources[[1]]$schema <- file.path(
+    "/tests/testthat/data/deployments_schema.json"
+  )
+  expect_error(
+    read_resource(p_unsafe, "deployments"),
+    paste(
+      "`/tests/testthat/data/deployments_schema.json` is an absolute path",
+      "(`/`) which is unsafe."
+    ),
+    fixed = TRUE
+  )
+
+  # Schema is relative parent path
+  p_unsafe$resources[[1]]$schema <- "../testthat/data/deployments_schema.json"
+  expect_error(
+    read_resource(p_unsafe, "deployments"),
+    paste(
+      "`../testthat/data/deployments_schema.json` is a relative parent path",
+      "(`../`) which is unsafe."
+    ),
+    fixed = TRUE
+  )
+
+  # Schema is local path
+  p_local_schema <- p
+  p_local_schema$resources[[1]]$schema <- "data/deployments_schema.json"
   expect_identical(read_resource(p_local_schema, "deployments"), resource)
 
+  # Schema is remote path
   p_remote_schema <- p
   p_remote_schema$resources[[1]]$schema <- file.path(
     "https://github.com/frictionlessdata/frictionless-r",
@@ -243,20 +246,45 @@ test_that("read_resource() can read local and remote Table Schemas", {
   expect_identical(read_resource(p_remote_schema, "deployments"), resource)
 })
 
-test_that("read_resource() can read local and remote CSV dialect", {
+test_that("read_resource() can read safe local and remote CSV dialect", {
   p <- example_package
   resource <- read_resource(p, "deployments")
-
-  p_local_dialect <- p
-  p_local_dialect$directory <- "." # Use "./tests/testthat/data" outside test
-  p_local_dialect$resources[[1]]$dialect <- "data/dialect.json"
-  # Using a remote path, otherwise schema and path need to share same directory
-  p_local_dialect$resources[[1]]$path <- file.path(
+  p$directory <- "."
+  # Using a remote path, otherwise dialect and path need to share same directory
+  p$resources[[1]]$path <- file.path(
     "https://github.com/frictionlessdata/frictionless-r",
     "raw/main/inst/extdata/deployments.csv"
   )
+
+  # Dialect is absolute path
+  p_unsafe <- p
+  p_unsafe$resources[[1]]$dialect <- "/tests/testthat/data/dialect.json"
+  expect_error(
+    read_resource(p_unsafe, "deployments"),
+    paste(
+      "`/tests/testthat/data/dialect.json` is an absolute path",
+      "(`/`) which is unsafe."
+    ),
+    fixed = TRUE
+  )
+
+  # Dialect is relative parent path
+  p_unsafe$resources[[1]]$dialect <- "../testthat/data/dialect.json"
+  expect_error(
+    read_resource(p_unsafe, "deployments"),
+    paste(
+      "`../testthat/data/dialect.json` is a relative parent path",
+      "(`../`) which is unsafe."
+    ),
+    fixed = TRUE
+  )
+
+  # Dialect is local path
+  p_local_dialect <- p
+  p_local_dialect$resources[[1]]$dialect <- "data/dialect.json"
   expect_identical(read_resource(p_local_dialect, "deployments"), resource)
 
+  # Dialect is remote path
   p_remote_dialect <- p
   p_remote_dialect$resources[[1]]$dialect <- file.path(
     "https://github.com/frictionlessdata/frictionless-r",
@@ -271,7 +299,7 @@ test_that("read_resource() understands CSV dialect", {
 
   # Create package with non-default dialect properties
   p_dialect <- p
-  p_dialect$directory <- "." # Use "./tests/testthat" outside test
+  p_dialect$directory <- "."
   p_dialect$resources[[1]]$path <- "data/deployments_dialect.csv"
   p_dialect$resources[[1]]$dialect <- list(
     delimiter = "/",
@@ -300,7 +328,7 @@ test_that("read_resource() understands missing values", {
 
   # Create package with non-default missing values
   p_missing <- p
-  p_missing$directory <- "." # Use "./tests/testthat" outside test
+  p_missing$directory <- "."
   p_missing$resources[[1]]$path <- "data/deployments_missingvalues.csv"
   p_missing$resources[[1]]$schema$missingValues <-
     append(p_missing$resources[[1]]$schema$missingValues, "ignore")
@@ -313,7 +341,7 @@ test_that("read_resource() understands encoding", {
 
   # Create package with non-default missing values
   p_encoding <- p
-  p_encoding$directory <- "." # Use "./tests/testthat" outside test
+  p_encoding$directory <- "."
   p_encoding$resources[[1]]$path <- "data/deployments_encoding.csv"
   p_encoding$resources[[1]]$encoding <- "windows-1252"
   expect_identical(read_resource(p_encoding, "deployments"), resource)
@@ -338,7 +366,7 @@ test_that("read_resource() handles LF and CRLF line terminator characters", {
   resource <- read_resource(p, "deployments") # This file has LF
 
   p_crlf <- p
-  p_crlf$directory <- "." # Use "./tests/testthat" outside test
+  p_crlf$directory <- "."
   p_crlf$resources[[1]]$path <- "data/deployments_crlf.csv" # File with CRLF
   expect_identical(read_resource(p_crlf, "deployments"), resource)
 })
@@ -350,7 +378,7 @@ test_that("read_resource() can read compressed files", {
   # File created in terminal with:
   # zip deployments.csv.zip deployments.csv
   p_local_zip <- p
-  p_local_zip$directory <- "." # Use "./tests/testthat" outside test
+  p_local_zip$directory <- "."
   p_local_zip$resources[[1]]$path <- "data/deployments.csv.zip"
   p_remote_zip <- p
   p_remote_zip$resources[[1]]$path <- file.path(
@@ -361,7 +389,7 @@ test_that("read_resource() can read compressed files", {
   # File created in terminal with:
   # gzip deployments.csv
   p_local_gz <- p
-  p_local_gz$directory <- "." # Use "./tests/testthat" outside test
+  p_local_gz$directory <- "."
   p_local_gz$resources[[1]]$path <- "data/deployments.csv.gz"
   p_remote_gz <- p
   p_remote_gz$resources[[1]]$path <- file.path(


### PR DESCRIPTION
Also includes stricter checks for input of `read_package()`.

In contrast with what was described in https://github.com/frictionlessdata/frictionless-r/issues/66#issuecomment-1004804842, the extension is checked on `yaml` or `yml` first and then defaults to reading with `fromJSON`. The reason is that `fromJSON` has clearer error messages when e.g. a `csv` file was provided.