### PR TITLE
Fix #83

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,11 +29,11 @@ Imports:
     utils,
     yaml
 Suggests:
-    knitr,
     hms,
+    knitr,
     lubridate,
-    testthat (>= 3.0.0),
-    rmarkdown
+    rmarkdown,
+    testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,18 +18,16 @@ replace_null <- function(x, replacement) {
 #' Get unique vector values sorted by how often they occur
 #'
 #' @param x Vector, e.g. `c("a", "b", "b", "b", "a")`.
-#' @return Vector with unique values sorted by occurrence, e.g. `c("b", "a")`.
+#' @return Vector with unique values sorted by desc. count, e.g. `c("b", "a")`.
 #' @family helper functions
 #' @noRd
 unique_sorted <- function(x) {
-  dplyr::pull(
-    dplyr::arrange(
-      # Create data.frame with values ("Group.1") and how often they occur ("x")
-      stats::aggregate(x, by = list(x), FUN = length),
-      dplyr::desc(x)
-    ),
-    "Group.1"
-  )
+  # Create data frame with values and how often they occur
+  df <- stats::aggregate(x, by = list(x), FUN = length)
+  colnames(df) <- c("value", "count")
+  # Sort dataframe on count (can only be ascending) and retrieve values
+  values <- df[with(df, order(count)),][[1]]
+  rev(values) # Reverse order
 }
 
 #' Clean list

--- a/codemeta.json
+++ b/codemeta.json
@@ -50,18 +50,6 @@
   "softwareSuggestions": [
     {
       "@type": "SoftwareApplication",
-      "identifier": "knitr",
-      "name": "knitr",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=knitr"
-    },
-    {
-      "@type": "SoftwareApplication",
       "identifier": "hms",
       "name": "hms",
       "provider": {
@@ -71,6 +59,18 @@
         "url": "https://cran.r-project.org"
       },
       "sameAs": "https://CRAN.R-project.org/package=hms"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "knitr",
+      "name": "knitr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=knitr"
     },
     {
       "@type": "SoftwareApplication",
@@ -86,6 +86,18 @@
     },
     {
       "@type": "SoftwareApplication",
+      "identifier": "rmarkdown",
+      "name": "rmarkdown",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=rmarkdown"
+    },
+    {
+      "@type": "SoftwareApplication",
       "identifier": "testthat",
       "name": "testthat",
       "version": ">= 3.0.0",
@@ -96,18 +108,6 @@
         "url": "https://cran.r-project.org"
       },
       "sameAs": "https://CRAN.R-project.org/package=testthat"
-    },
-    {
-      "@type": "SoftwareApplication",
-      "identifier": "rmarkdown",
-      "name": "rmarkdown",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=rmarkdown"
     }
   ],
   "softwareRequirements": {
@@ -208,9 +208,26 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=stringr"
     },
+    "9": {
+      "@type": "SoftwareApplication",
+      "identifier": "utils",
+      "name": "utils"
+    },
+    "10": {
+      "@type": "SoftwareApplication",
+      "identifier": "yaml",
+      "name": "yaml",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=yaml"
+    },
     "SystemRequirements": null
   },
-  "fileSize": "148.239KB",
+  "fileSize": "168.132KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",
@@ -235,6 +252,7 @@
       "sameAs": "https://doi.org/10.5281/zenodo.5815355"
     }
   ],
+  "releaseNotes": "https://github.com/frictionlessdata/frictionless-r/blob/master/NEWS.md",
   "readme": "https://github.com/frictionlessdata/frictionless-r/blob/main/README.md",
   "contIntegration": ["https://github.com/frictionlessdata/frictionless-r/actions", "https://codecov.io/gh/frictionlessdata/frictionless-r"],
   "developmentStatus": "https://www.repostatus.org/#active",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,48 @@
+test_that("replace_null() replaces NULL or returns value", {
+  expect_identical(frictionless:::replace_null(NULL, "y"), "y")
+  expect_identical(frictionless:::replace_null(NA, "y"), NA)
+  expect_identical(frictionless:::replace_null(1, "y"), 1)
+  expect_identical(frictionless:::replace_null("x", "y"), "x")
+})
+
+test_that("unique_sorted() returns unique values sorted by descending count", {
+  x <- c("a", "b", "b", "b", "c", "a")
+  expect_identical(frictionless:::unique_sorted(x), c("b", "a", "c"))
+})
+
+test_that("clean_list() removes elements from list that match condition", {
+  x <- list(
+    a = list(list(x = "value", y = NULL, z = list(v = NULL))),
+    b = NULL
+  )
+
+  # Default (non recursive remove NULL): b removed
+  expect_identical(
+    frictionless:::clean_list(x),
+    list(
+      a = list(list(x = "value", y = NULL, z = list(v = NULL)))
+    )
+  )
+
+  # Remove recursive: a[[1]]$y removed
+  expected_list <- list(
+    a = list(list(x = "value", z = list()))
+  )
+  names(expected_list$a[[1]]$z) <- character(0) # named list()
+  expect_identical(
+    frictionless:::clean_list(x, recursive = TRUE),
+    expected_list
+  )
+
+  # Remove recursive + empty elements: a[[1]]$z removed
+  expect_identical(
+    frictionless:::clean_list(
+      x,
+      function(x) is.null(x) | length(x) == 0L,
+      recursive = TRUE
+    ),
+    list(
+      a = list(list(x = "value"))
+    )
+  )
+})


### PR DESCRIPTION
Decided to **not drop** dplyr:

1. It's `bind_cols()` is much faster than the default `rbind()` ([source](https://stackoverflow.com/a/59482527/2463806))
2. It would require loading `tibble`, which is about the same size. `as_tibble()` and `tibble()` are exported from `dplyr` (as is `%>%`)

What was changed in this PR is an update of the util function `unique_sorted()` which now no longer requires dplyr (but just base R) and is a bit easier to read.