### PR TITLE
Support adding a schema via path or URL in add_resource()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - `add_resource()` now sets `format`, `mediatype` and `encoding` for added CSV 
   file(s) (#78).
+- `add_resource()` now supports adding `schema` via path or URL.
 - `read_resource()` will now warn rather than error on unknown encoding (#86).
 - `package` objects no longer have or require the custom attribute 
   `datapackage`, making it easier to edit them as lists (with e.g. `append()`).

--- a/R/add_resource.R
+++ b/R/add_resource.R
@@ -18,7 +18,8 @@
 #'     compare with `schema` and to set `format`, `mediatype` and `encoding`.
 #'     The other files are ignored, but are expected to have the same structure
 #'     and properties.
-#' @param schema List describing a Table Schema for the `data`.
+#' @param schema Either a list, or path or URL to a JSON file describing a Table
+#'   Schema for the `data`.
 #'   If not provided, one will be created using [create_schema()].
 #' @param delim Single character used to separate the fields in the CSV file(s),
 #'   e.g. `\t` for tab delimited file.
@@ -106,6 +107,9 @@ add_resource <- function(package, resource_name, data, schema = NULL,
   # Create schema
   if (is.null(schema)) {
     schema <- create_schema(df)
+  } else if (is.character(schema)) {
+    # Path to schema can be unsafe, since schema will be verbosely included
+    schema <- read_descriptor(schema, safe = FALSE)
   }
 
   # Check schema (also checks df)

--- a/R/read_resource.R
+++ b/R/read_resource.R
@@ -62,7 +62,7 @@
 #' `dialect` properties are
 #' [required](https://specs.frictionlessdata.io/csv-dialect/#specification) if
 #' the resource file(s) deviate from the default CSV settings (see below).
-#' It can either be a JSON object or a URL or path referencing a JSON object.
+#' It can either be a JSON object or a path or URL referencing a JSON object.
 #' Only deviating properties need to be specified, e.g. a tab delimited file
 #' without a header row needs:
 #' ```json
@@ -111,7 +111,7 @@
 #' @section Table schema properties:
 #' `schema` is required and must follow the [Table
 #' Schema](https://specs.frictionlessdata.io/table-schema/) specification.
-#' It can either be a JSON object or a URL or path referencing a JSON object.
+#' It can either be a JSON object or a path or URL referencing a JSON object.
 #'
 #' - Field `name`s are used as column headers.
 #' - Field `type`s are use as column types (see further).

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://frictionlessdata.github.io/frictionless-r
+url: ~
 
 template:
   bootstrap: 5

--- a/man/add_resource.Rd
+++ b/man/add_resource.Rd
@@ -24,7 +24,8 @@ The other files are ignored, but are expected to have the same structure
 and properties.
 }}
 
-\item{schema}{List describing a Table Schema for the \code{data}.
+\item{schema}{Either a list, or path or URL to a JSON file describing a Table
+Schema for the \code{data}.
 If not provided, one will be created using \code{\link[=create_schema]{create_schema()}}.}
 
 \item{delim}{Single character used to separate the fields in the CSV file(s),

--- a/man/example_package.Rd
+++ b/man/example_package.Rd
@@ -5,7 +5,7 @@
 \alias{example_package}
 \title{Example Data Package}
 \format{
-An object of class \code{datapackage} (inherits from \code{list}) of length 9.
+An object of class \code{list} of length 9.
 }
 \source{
 \url{https://github.com/frictionlessdata/frictionless-r/tree/main/inst/extdata}

--- a/man/read_resource.Rd
+++ b/man/read_resource.Rd
@@ -74,7 +74,7 @@ The returned data frame will always be UTF-8.
 \code{dialect} properties are
 \href{https://specs.frictionlessdata.io/csv-dialect/#specification}{required} if
 the resource file(s) deviate from the default CSV settings (see below).
-It can either be a JSON object or a URL or path referencing a JSON object.
+It can either be a JSON object or a path or URL referencing a JSON object.
 Only deviating properties need to be specified, e.g. a tab delimited file
 without a header row needs:\if{html}{\out{<div class="sourceCode json">}}\preformatted{"dialect": \{"delimiter": "\\t", "header": "false"\}
 }\if{html}{\out{</div>}}
@@ -129,7 +129,7 @@ the \code{compression} property is
 \section{Table schema properties}{
 
 \code{schema} is required and must follow the \href{https://specs.frictionlessdata.io/table-schema/}{Table Schema} specification.
-It can either be a JSON object or a URL or path referencing a JSON object.
+It can either be a JSON object or a path or URL referencing a JSON object.
 \itemize{
 \item Field \code{name}s are used as column headers.
 \item Field \code{type}s are use as column types (see further).

--- a/tests/testthat/data/schema_custom.json
+++ b/tests/testthat/data/schema_custom.json
@@ -1,0 +1,14 @@
+{
+  "fields": [
+    {
+      "name": "col_1",
+      "type": "number",
+      "title": "Column 1"
+    },
+    {
+      "name": "col_2",
+      "type": "string",
+      "title": "Column 2"
+    }
+  ]
+}

--- a/tests/testthat/test-add_resource.R
+++ b/tests/testthat/test-add_resource.R
@@ -182,7 +182,7 @@ test_that("add_resource() adds resource, resource_name", {
   )
 })
 
-test_that("add_resource() uses provided schema or creates one", {
+test_that("add_resource() uses provided schema (list or path) or creates one", {
   p <- create_package()
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
   df_csv <- "data/df.csv"
@@ -191,22 +191,29 @@ test_that("add_resource() uses provided schema or creates one", {
     list(name = "col_1", type = "number", title = "Column 1"),
     list(name = "col_2", type = "string", title = "Column 2")
   ))
+  schema_file <- "data/schema_custom.json" # Same content as schema_custom
 
   # df
   p <- add_resource(p, "new_df", df)
-  p <- add_resource(p, "new_df_with_schema", df, schema_custom)
+  p <- add_resource(p, "new_df_with_list_schema", df, schema_custom)
+  p <- add_resource(p, "new_df_with_file_schema", df, schema_file)
   expect_identical(p$resources[[1]]$schema, schema)
   expect_identical(p$resources[[2]]$schema, schema_custom)
+  expect_identical(p$resources[[3]]$schema, schema_custom)
   expect_identical(get_schema(p, "new_df"), schema)
-  expect_identical(get_schema(p, "new_df_with_schema"), schema_custom)
+  expect_identical(get_schema(p, "new_df_with_list_schema"), schema_custom)
+  expect_identical(get_schema(p, "new_df_with_file_schema"), schema_custom)
 
   # csv
   p <- add_resource(p, "new_csv", df)
-  p <- add_resource(p, "new_csv_with_schema", df, schema_custom)
-  expect_identical(p$resources[[3]]$schema, schema)
-  expect_identical(p$resources[[4]]$schema, schema_custom)
+  p <- add_resource(p, "new_csv_with_list_schema", df, schema_custom)
+  p <- add_resource(p, "new_csv_with_file_schema", df, schema_file)
+  expect_identical(p$resources[[4]]$schema, schema)
+  expect_identical(p$resources[[5]]$schema, schema_custom)
+  expect_identical(p$resources[[6]]$schema, schema_custom)
   expect_identical(get_schema(p, "new_csv"), schema)
-  expect_identical(get_schema(p, "new_csv_with_schema"), schema_custom)
+  expect_identical(get_schema(p, "new_csv_with_list_schema"), schema_custom)
+  expect_identical(get_schema(p, "new_csv_with_file_schema"), schema_custom)
 })
 
 test_that("add_resource() can add resource from data frame, readable by


### PR DESCRIPTION
Noticed I needed this for a project and makes sense as a general feature.