### PR TITLE
Set format based on delimiter in `add_resource()`

### DIFF
--- a/R/add_resource.R
+++ b/R/add_resource.R
@@ -94,14 +94,20 @@ add_resource <- function(package, resource_name, data, schema = NULL,
     # Check existence of files (no further checks) and read last file
     paths <- purrr::map_chr(data, ~ check_path(.x, safe = FALSE))
     last_file <- utils::tail(paths, n = 1)
-    extension <- utils::tail(strsplit(last_file, "\\.")[[1]], n = 1)
-    encoding <- readr::guess_encoding(last_file, n_max = 1000)[[1, 1]]
-    encoding <- replace_null(encoding, "UTF-8")
     df <- readr::read_delim(
-      file = paths[length(paths)],
+      file = last_file,
       delim = delim,
       show_col_types = FALSE,
     )
+
+    # Get extension, inspired by tools::file_ext()
+    file_name <- gsub("(\\.gz$)|(\\.zip$)", "", last_file) # Ignore compression
+    pos <- regexpr("\\.([[:alnum:]]+)$", file_name)
+    extension <- ifelse(pos > -1L, substring(file_name, pos + 1L), "csv")
+
+    # Get encoding
+    encoding <- readr::guess_encoding(last_file, n_max = 1000)[[1, 1]]
+    encoding <- replace_null(encoding, "UTF-8")
   }
 
   # Create schema

--- a/tests/testthat/test-add_resource.R
+++ b/tests/testthat/test-add_resource.R
@@ -298,7 +298,7 @@ test_that("add_resource() sets correct properties for CSV resources", {
     read_resource(p, "deployments")
   )
 
-  # Encoding UTF-8, compressed with zip
+  # Encoding UTF-8 (0.8), ISO-8859-1 (0.59), ISO-8859-2 (0.26), zip compressed
   p <- add_resource(p, "deployments_zip", "data/deployments.csv.zip")
   expect_identical(p$resources[[3]]$format, "csv") # .zip extension ignored
   expect_identical(p$resources[[3]]$mediatype, "text/csv")
@@ -308,33 +308,23 @@ test_that("add_resource() sets correct properties for CSV resources", {
     read_resource(p, "deployments")
   )
 
-  # Encoding UTF-8, compressed with gzip
-  p <- add_resource(p, "deployments_gz", "data/deployments.csv.gz")
-  expect_identical(p$resources[[4]]$format, "csv") # .gz extension ignored
-  expect_identical(p$resources[[4]]$mediatype, "text/csv")
-  expect_identical(p$resources[[4]]$encoding, "UTF-8")
-  expect_identical(
-    read_resource(p, "deployments_zip"),
-    read_resource(p, "deployments")
-  )
-
   # Encoding ASCII, delimiter ","
   p <- add_resource(p, "df", "data/df.csv")
-  expect_identical(p$resources[[5]]$format, "csv")
-  expect_identical(p$resources[[5]]$mediatype, "text/csv")
-  expect_identical(p$resources[[5]]$encoding, "UTF-8") # ASCII is set to UTF-8
+  expect_identical(p$resources[[4]]$format, "csv")
+  expect_identical(p$resources[[4]]$mediatype, "text/csv")
+  expect_identical(p$resources[[4]]$encoding, "UTF-8") # ASCII is set to UTF-8
 
   # Encoding ASCII, delimiter ";", extension "txt"
   p <- add_resource(p, "df_delim_1", "data/df_delim_1.txt", delim = ";")
-  expect_identical(p$resources[[6]]$format, "txt")
-  expect_identical(p$resources[[6]]$mediatype, "text/csv")
-  expect_identical(p$resources[[6]]$encoding, "UTF-8")
+  expect_identical(p$resources[[5]]$format, "csv")
+  expect_identical(p$resources[[5]]$mediatype, "text/csv")
+  expect_identical(p$resources[[5]]$encoding, "UTF-8")
   expect_identical(read_resource(p, "df_delim_1"), read_resource(p, "df"))
 
   # Encoding ASCII, delimiter "\t", extension "tsv"
   p <- add_resource(p, "df_delim_2", "data/df_delim_2.tsv", delim = "\t")
-  expect_identical(p$resources[[7]]$format, "tsv")
-  expect_identical(p$resources[[7]]$mediatype, "text/tab-separated-values")
-  expect_identical(p$resources[[7]]$encoding, "UTF-8")
+  expect_identical(p$resources[[6]]$format, "tsv")
+  expect_identical(p$resources[[6]]$mediatype, "text/tab-separated-values")
+  expect_identical(p$resources[[6]]$encoding, "UTF-8")
   expect_identical(read_resource(p, "df_delim_2"), read_resource(p, "df"))
 })

--- a/tests/testthat/test-add_resource.R
+++ b/tests/testthat/test-add_resource.R
@@ -298,23 +298,43 @@ test_that("add_resource() sets correct properties for CSV resources", {
     read_resource(p, "deployments")
   )
 
+  # Encoding UTF-8, compressed with zip
+  p <- add_resource(p, "deployments_zip", "data/deployments.csv.zip")
+  expect_identical(p$resources[[3]]$format, "csv") # .zip extension ignored
+  expect_identical(p$resources[[3]]$mediatype, "text/csv")
+  expect_identical(p$resources[[3]]$encoding, "UTF-8")
+  expect_identical(
+    read_resource(p, "deployments_zip"),
+    read_resource(p, "deployments")
+  )
+
+  # Encoding UTF-8, compressed with gzip
+  p <- add_resource(p, "deployments_gz", "data/deployments.csv.gz")
+  expect_identical(p$resources[[4]]$format, "csv") # .gz extension ignored
+  expect_identical(p$resources[[4]]$mediatype, "text/csv")
+  expect_identical(p$resources[[4]]$encoding, "UTF-8")
+  expect_identical(
+    read_resource(p, "deployments_zip"),
+    read_resource(p, "deployments")
+  )
+
   # Encoding ASCII, delimiter ","
   p <- add_resource(p, "df", "data/df.csv")
-  expect_identical(p$resources[[3]]$format, "csv")
-  expect_identical(p$resources[[3]]$mediatype, "text/csv")
-  expect_identical(p$resources[[3]]$encoding, "UTF-8") # ASCII is set to UTF-8
+  expect_identical(p$resources[[5]]$format, "csv")
+  expect_identical(p$resources[[5]]$mediatype, "text/csv")
+  expect_identical(p$resources[[5]]$encoding, "UTF-8") # ASCII is set to UTF-8
 
   # Encoding ASCII, delimiter ";", extension "txt"
   p <- add_resource(p, "df_delim_1", "data/df_delim_1.txt", delim = ";")
-  expect_identical(p$resources[[4]]$format, "txt")
-  expect_identical(p$resources[[4]]$mediatype, "text/csv")
-  expect_identical(p$resources[[4]]$encoding, "UTF-8")
+  expect_identical(p$resources[[6]]$format, "txt")
+  expect_identical(p$resources[[6]]$mediatype, "text/csv")
+  expect_identical(p$resources[[6]]$encoding, "UTF-8")
   expect_identical(read_resource(p, "df_delim_1"), read_resource(p, "df"))
 
   # Encoding ASCII, delimiter "\t", extension "tsv"
   p <- add_resource(p, "df_delim_2", "data/df_delim_2.tsv", delim = "\t")
-  expect_identical(p$resources[[5]]$format, "tsv")
-  expect_identical(p$resources[[5]]$mediatype, "text/tab-separated-values")
-  expect_identical(p$resources[[5]]$encoding, "UTF-8")
+  expect_identical(p$resources[[7]]$format, "tsv")
+  expect_identical(p$resources[[7]]$mediatype, "text/tab-separated-values")
+  expect_identical(p$resources[[7]]$encoding, "UTF-8")
   expect_identical(read_resource(p, "df_delim_2"), read_resource(p, "df"))
 })


### PR DESCRIPTION
This PR started as "ignoring compression extension" (first commit), but reading the specs again, I opted for a simpler approach where `format` can only be `csv` or `tsv` based on the delimiter:

https://github.com/frictionlessdata/frictionless-r/issues/90#issuecomment-1020234887

Fix #90