### PR TITLE
Add test for not overwriting existing files

### DIFF
--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -56,6 +56,31 @@ test_that("write_package() writes unaltered datapackage.json as is", {
   expect_identical(json_as_written, json_original)
 })
 
+test_that("write_package() does not overwrite existing data files", {
+  p <- suppressMessages(read_package(
+    system.file("extdata", "datapackage.json", package = "frictionless")
+  ))
+  dir <- file.path(tempdir(), "package")
+  on.exit(unlink(dir, recursive = TRUE))
+  dir.create(dir)
+
+  # Create files in directory
+  files <- c(
+    datapackage = file.path(dir, "datapackage.json"),
+    deployments = file.path(dir, "deployments.csv"),
+    observations_1 = file.path(dir, "observations_1.csv"),
+    observations_2 = file.path(dir, "observations_2.csv")
+  )
+  file.create(files) # Size for these files will be 0
+
+  # Write package to directory, expect only datapackage.json is overwritten
+  suppressMessages(write_package(p, dir))
+  expect_gt(file.info(files["datapackage"])$size, 0) # Overwitten
+  expect_equal(file.info(files["deployments"])$size, 0)
+  expect_equal(file.info(files["observations_1"])$size, 0)
+  expect_equal(file.info(files["observations_2"])$size, 0)
+})
+
 test_that("write_package() copies file(s) for path = local in local package", {
   p <- suppressMessages(read_package(
     system.file("extdata", "datapackage.json", package = "frictionless")


### PR DESCRIPTION
Fix #88.

Done by creating empty files, with size 0. When using `write_package()` to that directory, only `datapackage.json` should be altered, the other files should remain having size 0.