### PR TITLE
v1.0.1 for CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: frictionless
 Title: Read and Write Frictionless Data Packages
-Version: 1.0.0.9000
+Version: 1.0.1
 Authors@R: c(
     person("Peter", "Desmet", email = "peter.desmet.work@gmail.com",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-8442-8025")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # frictionless (development version)
 
+# frictionless 1.0.1
+
+- Rebuild documentation for compatibility with HTML5 on request of CRAN.
+- Add funder information.
+
 # frictionless 1.0.0
 
 - First release on [CRAN](https://cran.r-project.org/package=frictionless). 🎉

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,17 +4,23 @@
   "identifier": "frictionless",
   "description": "Read and write Frictionless Data Packages. A 'Data Package' (<https://specs.frictionlessdata.io/data-package/>) is a simple container format and standard to describe and package a collection of (tabular) data. It is typically used to publish FAIR (<https://www.go-fair.org/fair-principles/>) and open datasets.",
   "name": "frictionless: Read and Write Frictionless Data Packages",
-  "relatedLink": "https://docs.ropensci.org/frictionless/",
+  "relatedLink": ["https://docs.ropensci.org/frictionless/", "https://CRAN.R-project.org/package=frictionless"],
   "codeRepository": "https://github.com/frictionlessdata/frictionless-r",
   "issueTracker": "https://github.com/frictionlessdata/frictionless-r/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
     "url": "https://r-project.org"
   },
   "runtimePlatform": "R version 4.1.2 (2021-11-01)",
+  "provider": {
+    "@id": "https://cran.r-project.org",
+    "@type": "Organization",
+    "name": "Comprehensive R Archive Network (CRAN)",
+    "url": "https://cran.r-project.org"
+  },
   "author": [
     {
       "@type": "Person",
@@ -34,8 +40,13 @@
   "copyrightHolder": [
     {
       "@type": "Organization",
-      "name": "Research Institute for Nature and Forest (INBO)",
-      "email": "info@inbo.be"
+      "name": "Research Institute for Nature and Forest (INBO)"
+    }
+  ],
+  "funder": [
+    {
+      "@type": "Organization",
+      "name": "LifeWatch Belgium"
     }
   ],
   "maintainer": [
@@ -215,7 +226,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "177.956KB",
+  "fileSize": "178.01KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",
@@ -224,25 +235,29 @@
         {
           "@type": "Person",
           "givenName": "Peter",
-          "familyName": "Desmet"
+          "familyName": "Desmet",
+          "email": "peter.desmet.work@gmail.com",
+          "@id": "https://orcid.org/0000-0002-8442-8025"
         },
         {
           "@type": "Person",
           "givenName": "Damiano",
-          "familyName": "Oldoni"
+          "familyName": "Oldoni",
+          "email": "damiano.oldoni@inbo.be",
+          "@id": "https://orcid.org/0000-0003-3445-7562"
         }
       ],
-      "name": "frictionless: Read and Write Frictionless Data Packages",
+      "name": "Read and Write Frictionless Data Packages",
       "identifier": "10.5281/zenodo.5815355",
-      "url": "https://github.com/frictionlessdata/frictionless-r",
-      "description": "R package version 1.0.0",
+      "url": "https://cran.r-project.org/package=frictionless",
+      "description": "R package version 1.0.1",
       "@id": "https://doi.org/10.5281/zenodo.5815355",
       "sameAs": "https://doi.org/10.5281/zenodo.5815355"
     }
   ],
   "releaseNotes": "https://github.com/frictionlessdata/frictionless-r/blob/master/NEWS.md",
   "readme": "https://github.com/frictionlessdata/frictionless-r/blob/main/README.md",
-  "contIntegration": ["https://github.com/frictionlessdata/frictionless-r/actions", "https://app.codecov.io/gh/frictionlessdata/frictionless-r/"],
+  "contIntegration": ["https://github.com/frictionlessdata/frictionless-r/actions/workflows/R-CMD-check.yaml", "https://app.codecov.io/gh/frictionlessdata/frictionless-r/"],
   "developmentStatus": "https://www.repostatus.org/#active",
   "review": {
     "@type": "Review",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,11 +1,3 @@
 ## R CMD check results
 
-0 errors | 0 warnings | 2 notes
-
-* This is a new release.
-
-* Possibly misspelled words in DESCRIPTION:
-  Frictionless (2:23, 16:29)
-  
-  "Frictionless" is capitalized because it refers to an existing framework of 
-  software and standards to facilitate data use <https://frictionlessdata.io/>.
+0 errors | 0 warnings | 0 notes

--- a/man/frictionless-package.Rd
+++ b/man/frictionless-package.Rd
@@ -6,7 +6,7 @@
 \alias{frictionless-package}
 \title{frictionless: Read and Write Frictionless Data Packages}
 \description{
-Read and write Frictionless Data Packages. A 'Data Package' (<https://specs.frictionlessdata.io/data-package/>) is a simple container format and standard to describe and package a collection of (tabular) data. It is typically used to publish FAIR (<https://www.go-fair.org/fair-principles/>) and open datasets.
+Read and write Frictionless Data Packages. A 'Data Package' (\url{https://specs.frictionlessdata.io/data-package/}) is a simple container format and standard to describe and package a collection of (tabular) data. It is typically used to publish FAIR (\url{https://www.go-fair.org/fair-principles/}) and open datasets.
 }
 \seealso{
 Useful links:
@@ -28,6 +28,7 @@ Authors:
 Other contributors:
 \itemize{
   \item Research Institute for Nature and Forest (INBO) (https://www.vlaanderen.be/inbo/en-gb/) [copyright holder]
+  \item LifeWatch Belgium (https://lifewatch.be) [funder]
   \item Beatriz Milz \email{milz.bea@gmail.com} (\href{https://orcid.org/0000-0002-3064-4486}{ORCID}) [reviewer]
   \item João Martins \email{joao.martins@gmx.net} (\href{https://orcid.org/0000-0001-7961-4280}{ORCID}) [reviewer]
 }

--- a/man/read_resource.Rd
+++ b/man/read_resource.Rd
@@ -76,7 +76,9 @@ The returned data frame will always be UTF-8.
 the resource file(s) deviate from the default CSV settings (see below).
 It can either be a JSON object or a path or URL referencing a JSON object.
 Only deviating properties need to be specified, e.g. a tab delimited file
-without a header row needs:\if{html}{\out{<div class="sourceCode json">}}\preformatted{"dialect": \{"delimiter": "\\t", "header": "false"\}
+without a header row needs:
+
+\if{html}{\out{<div class="sourceCode json">}}\preformatted{"dialect": \{"delimiter": "\\t", "header": "false"\}
 }\if{html}{\out{</div>}}
 
 These are the CSV dialect properties.

--- a/vignettes/frictionless.Rmd
+++ b/vignettes/frictionless.Rmd
@@ -202,6 +202,6 @@ unlink("my_directory", recursive = TRUE)
 
 The frictionless pkg does not provide functionality to deposit your Data Package on a research repository such as [Zenodo](https://zenodo.org), but here are some tips:
 
-1. Validate your Data Package before depositing. You can do this in Python with the [Frictionless Framework](https://github.com/frictionlessdata/frictionless-py) using `frictionless validate datapackage.json`.
+1. Validate your Data Package before depositing. You can do this in Python with the [Frictionless Framework](https://github.com/frictionlessdata/framework) using `frictionless validate datapackage.json`.
 2. Zip the individual CSV files (and update their paths in `datapackage.json`) to reduce size, not the entire Data Package. That way, users still have direct access to the `datapackage.json` file. See [this example](https://zenodo.org/record/5061303#files).
 3. Only describe the technical aspects of your dataset in `datapackage.json` (fields, units, the dataset identifier in `id`). Authors, methodology, license, etc. are better described in the metadata fields the research repository provides.


### PR DESCRIPTION
## Cran submission

Done with `devtools::release()`

Version: 1.0.1
Date: 2022-09-07 19:56:38 UTC
SHA: e3fba3a7d3682a9b4081c45df3a75f4fd81dc3c8

! Don't forget to tag this release once accepted by CRAN