### PR TITLE
 suppress messages from read_package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/R/read_package.R
+++ b/R/read_package.R
@@ -5,8 +5,8 @@
 #' that describes the Data Package metadata and its Data Resources.
 #'
 #' @param file Path or URL to a `datapackage.json` file.
-#' @param silently Do you want to suppress the rights/citations reminder?
-#'    This reminder can be disabled by setting `silently = TRUE`
+#' @param quietly Do you want to suppress the rights/citations reminder?
+#'    This reminder can be disabled by setting `quietly = TRUE`
 #' @return List describing a Data Package.
 #'   The function will add a custom property `directory` with the directory the
 #'   descriptor was read from.
@@ -25,7 +25,7 @@
 #'
 #' # List resources
 #' resources(package)
-read_package <- function(file = "datapackage.json", silently = FALSE) {
+read_package <- function(file = "datapackage.json", quietly = FALSE) {
   # Read file
   assertthat::assert_that(
     is.character(file),
@@ -65,7 +65,7 @@ read_package <- function(file = "datapackage.json", silently = FALSE) {
   }
 
   ## Optionally supress the message
-  if (!isTRUE(silently)) {
+  if (!isTRUE(quietly)) {
     message(msg)
   }
 

--- a/R/read_package.R
+++ b/R/read_package.R
@@ -48,13 +48,18 @@ read_package <- function(file = "datapackage.json", quiet = FALSE) {
   # Add directory
   descriptor$directory <- dirname(file) # Also works for URLs
 
-  # Inform user regarding rights/citations
+  # Inform user regarding rights/citations unless silenced
   msg <- glue::glue(
     "Please make sure you have the right to access data from this Data Package",
     "for your intended use.\nFollow applicable norms or requirements to credit",
     "the dataset and its authors.",
     .sep = " "
   )
+
+  if (!isTRUE(quiet)) {
+    message(msg)
+  }
+
   if (!is.null(descriptor$id)) {
     if (startsWith(descriptor$id, "http")) {
       msg <- glue::glue(
@@ -62,11 +67,6 @@ read_package <- function(file = "datapackage.json", quiet = FALSE) {
         .sep = "\n"
       )
     }
-  }
-
-  ## Optionally supress the message
-  if (!isTRUE(quiet)) {
-    message(msg)
   }
 
   descriptor

--- a/R/read_package.R
+++ b/R/read_package.R
@@ -5,7 +5,7 @@
 #' that describes the Data Package metadata and its Data Resources.
 #'
 #' @param file Path or URL to a `datapackage.json` file.
-#' @param quietly A logical. If `TRUE` no reminder about citations/rights
+#' @param quiet A logical. If `TRUE` no reminder about citations/rights
 #'   regarding the usage of the read Data Package will be displayed.
 #' @return List describing a Data Package.
 #'   The function will add a custom property `directory` with the directory the
@@ -25,7 +25,7 @@
 #'
 #' # List resources
 #' resources(package)
-read_package <- function(file = "datapackage.json", quietly = FALSE) {
+read_package <- function(file = "datapackage.json", quiet = FALSE) {
   # Read file
   assertthat::assert_that(
     is.character(file),
@@ -65,7 +65,7 @@ read_package <- function(file = "datapackage.json", quietly = FALSE) {
   }
 
   ## Optionally supress the message
-  if (!isTRUE(quietly)) {
+  if (!isTRUE(quiet)) {
     message(msg)
   }
 

--- a/R/read_package.R
+++ b/R/read_package.R
@@ -5,7 +5,7 @@
 #' that describes the Data Package metadata and its Data Resources.
 #'
 #' @param file Path or URL to a `datapackage.json` file.
-#' @param quiet A logical. If `TRUE` no reminder about citations/rights
+#' @param quiet If `TRUE`, do not show message about access rights.
 #'   regarding the usage of the read Data Package will be displayed.
 #' @return List describing a Data Package.
 #'   The function will add a custom property `directory` with the directory the

--- a/R/read_package.R
+++ b/R/read_package.R
@@ -5,8 +5,8 @@
 #' that describes the Data Package metadata and its Data Resources.
 #'
 #' @param file Path or URL to a `datapackage.json` file.
-#' @param quietly Do you want to suppress the rights/citations reminder?
-#'    This reminder can be disabled by setting `quietly = TRUE`
+#' @param quietly A logical. If `TRUE` no reminder about citations/rights
+#'   regarding the usage of the read Data Package will be displayed.
 #' @return List describing a Data Package.
 #'   The function will add a custom property `directory` with the directory the
 #'   descriptor was read from.

--- a/R/read_package.R
+++ b/R/read_package.R
@@ -5,6 +5,8 @@
 #' that describes the Data Package metadata and its Data Resources.
 #'
 #' @param file Path or URL to a `datapackage.json` file.
+#' @param silently Do you want to suppress the rights/citations reminder?
+#'    This reminder can be disabled by setting `silently = TRUE`
 #' @return List describing a Data Package.
 #'   The function will add a custom property `directory` with the directory the
 #'   descriptor was read from.
@@ -23,7 +25,7 @@
 #'
 #' # List resources
 #' resources(package)
-read_package <- function(file = "datapackage.json") {
+read_package <- function(file = "datapackage.json", silently = FALSE) {
   # Read file
   assertthat::assert_that(
     is.character(file),
@@ -61,7 +63,11 @@ read_package <- function(file = "datapackage.json") {
       )
     }
   }
-  message(msg)
+
+  ## Optionally supress the message
+  if (!isTRUE(silently)) {
+    message(msg)
+  }
 
   descriptor
 }

--- a/man/read_package.Rd
+++ b/man/read_package.Rd
@@ -9,8 +9,8 @@ read_package(file = "datapackage.json", quietly = FALSE)
 \arguments{
 \item{file}{Path or URL to a \code{datapackage.json} file.}
 
-\item{quietly}{Do you want to suppress the rights/citations reminder?
-This reminder can be disabled by setting \code{quietly = TRUE}}
+\item{quietly}{A logical. If \code{TRUE} no reminder about citations/rights
+regarding the usage of the read Data Package will be displayed.}
 }
 \value{
 List describing a Data Package.

--- a/man/read_package.Rd
+++ b/man/read_package.Rd
@@ -4,13 +4,13 @@
 \alias{read_package}
 \title{Read a Data Package descriptor file (\code{datapackage.json})}
 \usage{
-read_package(file = "datapackage.json", silently = FALSE)
+read_package(file = "datapackage.json", quietly = FALSE)
 }
 \arguments{
 \item{file}{Path or URL to a \code{datapackage.json} file.}
 
-\item{silently}{Do you want to suppress the rights/citations reminder?
-This reminder can be disabled by setting \code{silently = TRUE}}
+\item{quietly}{Do you want to suppress the rights/citations reminder?
+This reminder can be disabled by setting \code{quietly = TRUE}}
 }
 \value{
 List describing a Data Package.

--- a/man/read_package.Rd
+++ b/man/read_package.Rd
@@ -4,10 +4,13 @@
 \alias{read_package}
 \title{Read a Data Package descriptor file (\code{datapackage.json})}
 \usage{
-read_package(file = "datapackage.json")
+read_package(file = "datapackage.json", silently = FALSE)
 }
 \arguments{
 \item{file}{Path or URL to a \code{datapackage.json} file.}
+
+\item{silently}{Do you want to suppress the rights/citations reminder?
+This reminder can be disabled by setting \code{silently = TRUE}}
 }
 \value{
 List describing a Data Package.

--- a/man/read_package.Rd
+++ b/man/read_package.Rd
@@ -4,12 +4,12 @@
 \alias{read_package}
 \title{Read a Data Package descriptor file (\code{datapackage.json})}
 \usage{
-read_package(file = "datapackage.json", quietly = FALSE)
+read_package(file = "datapackage.json", quiet = FALSE)
 }
 \arguments{
 \item{file}{Path or URL to a \code{datapackage.json} file.}
 
-\item{quietly}{A logical. If \code{TRUE} no reminder about citations/rights
+\item{quiet}{A logical. If \code{TRUE} no reminder about citations/rights
 regarding the usage of the read Data Package will be displayed.}
 }
 \value{

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -145,10 +145,7 @@ test_that("read_package() allows YAML descriptor", {
   )
 })
 
-test_that(paste(
-  "read_package() quiet argument allows to toggle",
-  "the rights/citation reminder"
-), {
+test_that("read_package() can silence message with quiet=TRUE", {
   p_path <- system.file("extdata", "datapackage.json", package = "frictionless")
   expect_message(read_package(p_path, quiet = FALSE))
   expect_no_message(read_package(p_path, quiet = TRUE))

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -148,5 +148,6 @@ test_that("read_package() allows YAML descriptor", {
 test_that("read_package() can silence message with quiet=TRUE", {
   p_path <- system.file("extdata", "datapackage.json", package = "frictionless")
   expect_message(read_package(p_path, quiet = FALSE))
+  expect_message(read_package(p_path))
   expect_no_message(read_package(p_path, quiet = TRUE))
 })

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -2,9 +2,10 @@ test_that("read_package() returns a valid Data Package reading from path", {
   # Load example package locally and a valid minimal one
   p_path <- system.file("extdata", "datapackage.json", package = "frictionless")
   minimal_path <- test_path("data/valid_minimal.json")
-  p_local <- suppressMessages(read_package(p_path))
-  p_minimal <- suppressMessages(read_package(minimal_path))
-
+  # p_local <- suppressMessages(read_package(p_path))
+  p_local <- read_package(p_path, quietly = TRUE)
+  # p_minimal <- suppressMessages(read_package(minimal_path))
+  p_minimal <- read_package(minimal_path, quietly = TRUE)
   # Returns a list with required properties
   expect_true(check_package(p_local))
   expect_true(check_package(p_minimal))
@@ -24,8 +25,8 @@ test_that("read_package() returns a valid Data Package reading from url", {
   # Load example package remotely
   p_url <- file.path("https://raw.githubusercontent.com/frictionlessdata/",
                      "frictionless-r/main/inst/extdata/datapackage.json")
-  p_remote <- suppressMessages(read_package(p_url))
-
+  # p_remote <- suppressMessages(read_package(p_url))
+  p_remote <- read_package(p_url, quietly = TRUE)
   # Returns a list with required properties
   expect_true(check_package(p_remote))
 
@@ -131,18 +132,21 @@ test_that("read_package() allows descriptor at absolute or relative parent
            path", {
   relative_path <- "../testthat/data/valid_minimal.json"
   expect_true(
-    check_package(suppressMessages(read_package(relative_path)))
+    # check_package(suppressMessages(read_package(relative_path)))
+    check_package(read_package(relative_path, quietly = TRUE))
   )
   absolute_path <- normalizePath("data/valid_minimal.json")
   expect_true(
-    check_package(suppressMessages(read_package(absolute_path)))
+    # check_package(suppressMessages(read_package(absolute_path)))
+    check_package(read_package(absolute_path, quietly = TRUE))
   )
 })
 
 test_that("read_package() allows YAML descriptor", {
   expect_true(
     check_package(
-      suppressMessages(read_package(test_path("data/valid_minimal.yml")))
+      # suppressMessages(read_package(test_path("data/valid_minimal.yml")))
+      read_package(test_path("data/valid_minimal.yml"), quietly = TRUE)
     )
   )
 })

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -144,3 +144,12 @@ test_that("read_package() allows YAML descriptor", {
     )
   )
 })
+
+test_that(paste(
+  "read_package() quietly argument allows to toggle",
+  "the rights/citation reminder"
+), {
+  p_path <- system.file("extdata", "datapackage.json", package = "frictionless")
+  expect_message(read_package(p_path, quietly = FALSE))
+  expect_no_message(read_package(p_path, quietly = TRUE))
+})

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -2,9 +2,7 @@ test_that("read_package() returns a valid Data Package reading from path", {
   # Load example package locally and a valid minimal one
   p_path <- system.file("extdata", "datapackage.json", package = "frictionless")
   minimal_path <- test_path("data/valid_minimal.json")
-  # p_local <- suppressMessages(read_package(p_path))
   p_local <- read_package(p_path, quietly = TRUE)
-  # p_minimal <- suppressMessages(read_package(minimal_path))
   p_minimal <- read_package(minimal_path, quietly = TRUE)
   # Returns a list with required properties
   expect_true(check_package(p_local))
@@ -25,7 +23,6 @@ test_that("read_package() returns a valid Data Package reading from url", {
   # Load example package remotely
   p_url <- file.path("https://raw.githubusercontent.com/frictionlessdata/",
                      "frictionless-r/main/inst/extdata/datapackage.json")
-  # p_remote <- suppressMessages(read_package(p_url))
   p_remote <- read_package(p_url, quietly = TRUE)
   # Returns a list with required properties
   expect_true(check_package(p_remote))
@@ -132,12 +129,10 @@ test_that("read_package() allows descriptor at absolute or relative parent
            path", {
   relative_path <- "../testthat/data/valid_minimal.json"
   expect_true(
-    # check_package(suppressMessages(read_package(relative_path)))
     check_package(read_package(relative_path, quietly = TRUE))
   )
   absolute_path <- normalizePath("data/valid_minimal.json")
   expect_true(
-    # check_package(suppressMessages(read_package(absolute_path)))
     check_package(read_package(absolute_path, quietly = TRUE))
   )
 })
@@ -145,7 +140,6 @@ test_that("read_package() allows descriptor at absolute or relative parent
 test_that("read_package() allows YAML descriptor", {
   expect_true(
     check_package(
-      # suppressMessages(read_package(test_path("data/valid_minimal.yml")))
       read_package(test_path("data/valid_minimal.yml"), quietly = TRUE)
     )
   )

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -2,8 +2,8 @@ test_that("read_package() returns a valid Data Package reading from path", {
   # Load example package locally and a valid minimal one
   p_path <- system.file("extdata", "datapackage.json", package = "frictionless")
   minimal_path <- test_path("data/valid_minimal.json")
-  p_local <- read_package(p_path, quietly = TRUE)
-  p_minimal <- read_package(minimal_path, quietly = TRUE)
+  p_local <- read_package(p_path, quiet = TRUE)
+  p_minimal <- read_package(minimal_path, quiet = TRUE)
   # Returns a list with required properties
   expect_true(check_package(p_local))
   expect_true(check_package(p_minimal))
@@ -23,7 +23,7 @@ test_that("read_package() returns a valid Data Package reading from url", {
   # Load example package remotely
   p_url <- file.path("https://raw.githubusercontent.com/frictionlessdata/",
                      "frictionless-r/main/inst/extdata/datapackage.json")
-  p_remote <- read_package(p_url, quietly = TRUE)
+  p_remote <- read_package(p_url, quiet = TRUE)
   # Returns a list with required properties
   expect_true(check_package(p_remote))
 
@@ -129,27 +129,27 @@ test_that("read_package() allows descriptor at absolute or relative parent
            path", {
   relative_path <- "../testthat/data/valid_minimal.json"
   expect_true(
-    check_package(read_package(relative_path, quietly = TRUE))
+    check_package(read_package(relative_path, quiet = TRUE))
   )
   absolute_path <- normalizePath("data/valid_minimal.json")
   expect_true(
-    check_package(read_package(absolute_path, quietly = TRUE))
+    check_package(read_package(absolute_path, quiet = TRUE))
   )
 })
 
 test_that("read_package() allows YAML descriptor", {
   expect_true(
     check_package(
-      read_package(test_path("data/valid_minimal.yml"), quietly = TRUE)
+      read_package(test_path("data/valid_minimal.yml"), quiet = TRUE)
     )
   )
 })
 
 test_that(paste(
-  "read_package() quietly argument allows to toggle",
+  "read_package() quiet argument allows to toggle",
   "the rights/citation reminder"
 ), {
   p_path <- system.file("extdata", "datapackage.json", package = "frictionless")
-  expect_message(read_package(p_path, quietly = FALSE))
-  expect_no_message(read_package(p_path, quietly = TRUE))
+  expect_message(read_package(p_path, quiet = FALSE))
+  expect_no_message(read_package(p_path, quiet = TRUE))
 })

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -186,7 +186,7 @@ test_that("read_resource() can read local files", {
 
   p_local <- read_package(
     system.file("extdata", "datapackage.json", package = "frictionless"),
-    quietly = TRUE
+    quiet = TRUE
   )
   expect_identical(read_resource(p_local, "deployments"), resource)
 })
@@ -386,7 +386,7 @@ test_that("read_resource() understands encoding", {
 
 test_that("read_resource() handles decimalChar/groupChar properties", {
   expected_value <- 3000000.3
-  p <- read_package(test_path("data/mark.json"), quietly = TRUE)
+  p <- read_package(test_path("data/mark.json"), quiet = TRUE)
 
   # Default decimalChar/groupChar
   resource <- read_resource(p, "mark_default")
@@ -503,7 +503,7 @@ test_that("read_resource() can read compressed files", {
 })
 
 test_that("read_resource() handles strings", {
-  p <- read_package(test_path("data/types.json"), quietly = TRUE)
+  p <- read_package(test_path("data/types.json"), quiet = TRUE)
   resource <- read_resource(p, "string")
   expect_type(resource$str, "character")
 
@@ -514,7 +514,7 @@ test_that("read_resource() handles strings", {
 })
 
 test_that("read_resource() handles numbers", {
-  p <- read_package(test_path("data/types.json"), quietly = TRUE)
+  p <- read_package(test_path("data/types.json"), quiet = TRUE)
   resource <- read_resource(p, "number")
 
   # Leading/trailing zeros are optional, + is assumed
@@ -547,7 +547,7 @@ test_that("read_resource() handles numbers", {
 })
 
 test_that("read_resource() handles integers (as doubles)", {
-  p <- read_package(test_path("data/types.json"), quietly = TRUE)
+  p <- read_package(test_path("data/types.json"), quiet = TRUE)
   resource <- read_resource(p, "integer")
 
   # Leading/trailing zeros are optional, + is assumed
@@ -569,7 +569,7 @@ test_that("read_resource() handles integers (as doubles)", {
 })
 
 test_that("read_resource() handles booleans", {
-  p <- read_package(test_path("data/types.json"), quietly = TRUE)
+  p <- read_package(test_path("data/types.json"), quiet = TRUE)
   resource <- read_resource(p, "boolean")
 
   # Default trueValues/falseValues are cast to logical
@@ -581,7 +581,7 @@ test_that("read_resource() handles booleans", {
 
 test_that("read_resource() handles dates", {
   expected_value <- as.Date("2013-11-23")
-  p <- read_package(test_path("data/types.json"), quietly = TRUE)
+  p <- read_package(test_path("data/types.json"), quiet = TRUE)
   resource <- read_resource(p, "date")
   # This test covers:
   # - year: %Y %y
@@ -602,7 +602,7 @@ test_that("read_resource() handles dates", {
 
 test_that("read_resource() handles times", {
   expected_value <- hms::hms(0, 30, 8) # "08:30:00"
-  p <- read_package(test_path("data/types.json"), quietly = TRUE)
+  p <- read_package(test_path("data/types.json"), quiet = TRUE)
   resource <- read_resource(p, "time")
   # This test covers:
   # - hour: %H (including 1 digit) %I + %p
@@ -626,7 +626,7 @@ test_that("read_resource() handles times", {
 
 test_that("read_resource() handles datetimes", {
   expected_value <- as.POSIXct("2013-11-23 08:30:00", tz = "UTC")
-  p <- read_package(test_path("data/types.json"), quietly = TRUE)
+  p <- read_package(test_path("data/types.json"), quiet = TRUE)
   resource <- read_resource(p, "datetime")
 
   expect_identical(resource$dttm_undefined, resource$dttm_default)
@@ -641,7 +641,7 @@ test_that("read_resource() handles datetimes", {
 })
 
 test_that("read_resource() handles other types", {
-  p <- read_package(test_path("data/types.json"), quietly = TRUE)
+  p <- read_package(test_path("data/types.json"), quiet = TRUE)
   resource <- read_resource(p, "other")
 
   # Interpret year, yearmonth as dates

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -184,9 +184,10 @@ test_that("read_resource() can read local files", {
   p <- example_package
   resource <- read_resource(p, "deployments") # local resource, remote package
 
-  p_local <- suppressMessages(read_package(
-    system.file("extdata", "datapackage.json", package = "frictionless")
-  ))
+  p_local <- read_package(
+    system.file("extdata", "datapackage.json", package = "frictionless"),
+    quietly = TRUE
+  )
   expect_identical(read_resource(p_local, "deployments"), resource)
 })
 
@@ -385,7 +386,7 @@ test_that("read_resource() understands encoding", {
 
 test_that("read_resource() handles decimalChar/groupChar properties", {
   expected_value <- 3000000.3
-  p <- suppressMessages(read_package(test_path("data/mark.json")))
+  p <- read_package(test_path("data/mark.json"), quietly = TRUE)
 
   # Default decimalChar/groupChar
   resource <- read_resource(p, "mark_default")
@@ -502,7 +503,7 @@ test_that("read_resource() can read compressed files", {
 })
 
 test_that("read_resource() handles strings", {
-  p <- suppressMessages(read_package(test_path("data/types.json")))
+  p <- read_package(test_path("data/types.json"), quietly = TRUE)
   resource <- read_resource(p, "string")
   expect_type(resource$str, "character")
 
@@ -513,7 +514,7 @@ test_that("read_resource() handles strings", {
 })
 
 test_that("read_resource() handles numbers", {
-  p <- suppressMessages(read_package(test_path("data/types.json")))
+  p <- read_package(test_path("data/types.json"), quietly = TRUE)
   resource <- read_resource(p, "number")
 
   # Leading/trailing zeros are optional, + is assumed
@@ -546,7 +547,7 @@ test_that("read_resource() handles numbers", {
 })
 
 test_that("read_resource() handles integers (as doubles)", {
-  p <- suppressMessages(read_package(test_path("data/types.json")))
+  p <- read_package(test_path("data/types.json"), quietly = TRUE)
   resource <- read_resource(p, "integer")
 
   # Leading/trailing zeros are optional, + is assumed
@@ -568,7 +569,7 @@ test_that("read_resource() handles integers (as doubles)", {
 })
 
 test_that("read_resource() handles booleans", {
-  p <- suppressMessages(read_package(test_path("data/types.json")))
+  p <- read_package(test_path("data/types.json"), quietly = TRUE)
   resource <- read_resource(p, "boolean")
 
   # Default trueValues/falseValues are cast to logical
@@ -580,7 +581,7 @@ test_that("read_resource() handles booleans", {
 
 test_that("read_resource() handles dates", {
   expected_value <- as.Date("2013-11-23")
-  p <- suppressMessages(read_package(test_path("data/types.json")))
+  p <- read_package(test_path("data/types.json"), quietly = TRUE)
   resource <- read_resource(p, "date")
   # This test covers:
   # - year: %Y %y
@@ -601,7 +602,7 @@ test_that("read_resource() handles dates", {
 
 test_that("read_resource() handles times", {
   expected_value <- hms::hms(0, 30, 8) # "08:30:00"
-  p <- suppressMessages(read_package(test_path("data/types.json")))
+  p <- read_package(test_path("data/types.json"), quietly = TRUE)
   resource <- read_resource(p, "time")
   # This test covers:
   # - hour: %H (including 1 digit) %I + %p
@@ -625,7 +626,7 @@ test_that("read_resource() handles times", {
 
 test_that("read_resource() handles datetimes", {
   expected_value <- as.POSIXct("2013-11-23 08:30:00", tz = "UTC")
-  p <- suppressMessages(read_package(test_path("data/types.json")))
+  p <- read_package(test_path("data/types.json"), quietly = TRUE)
   resource <- read_resource(p, "datetime")
 
   expect_identical(resource$dttm_undefined, resource$dttm_default)
@@ -640,7 +641,7 @@ test_that("read_resource() handles datetimes", {
 })
 
 test_that("read_resource() handles other types", {
-  p <- suppressMessages(read_package(test_path("data/types.json")))
+  p <- read_package(test_path("data/types.json"), quietly = TRUE)
   resource <- read_resource(p, "other")
 
   # Interpret year, yearmonth as dates

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -6,7 +6,7 @@ test_that("write_package() returns output Data Package (invisibly)", {
   on.exit(unlink(dir, recursive = TRUE))
   p_written <- suppressMessages(write_package(p, dir))
   p_from_file <-
-    read_package(file.path(dir, "datapackage.json"), quietly = TRUE)
+    read_package(file.path(dir, "datapackage.json"), quiet = TRUE)
   # p_from_file$directory will differ: overwrite to make the same
   p_from_file$directory <- p_written$directory
 
@@ -44,7 +44,7 @@ test_that("write_package() writes unaltered datapackage.json as is", {
   p_file <- system.file("extdata", "datapackage.json", package = "frictionless")
   json_original <- readr::read_lines(p_file) # Will use line endings of system
 
-  p <- read_package(p_file, quietly = TRUE)
+  p <- read_package(p_file, quiet = TRUE)
   dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
   suppressMessages(write_package(p, dir))
@@ -59,7 +59,7 @@ test_that("write_package() does not overwrite existing data files", {
   testthat::skip_if_offline()
   p <- read_package(
     system.file("extdata", "datapackage.json", package = "frictionless"),
-    quietly = TRUE
+    quiet = TRUE
   )
   dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
@@ -86,7 +86,7 @@ test_that("write_package() copies file(s) for path = local in local package", {
   testthat::skip_if_offline()
   p <- read_package(
     system.file("extdata", "datapackage.json", package = "frictionless"),
-    quietly = TRUE
+    quiet = TRUE
   )
   p$resources[[2]]$path[[2]] <- "observations_2.csv" # Make one URL a local path
   p <- add_resource(p, "new", test_path("data/df.csv"))
@@ -142,7 +142,7 @@ test_that("write_package() leaves as is for path = URL in local package", {
   testthat::skip_if_offline()
   p <- read_package(
     system.file("extdata", "datapackage.json", package = "frictionless"),
-    quietly = TRUE
+    quiet = TRUE
   )
   p <- add_resource(p, "new", file.path(
     "https://raw.githubusercontent.com/frictionlessdata/frictionless-r",
@@ -187,7 +187,7 @@ test_that("write_package() leaves as is for data = json in local package", {
   testthat::skip_if_offline()
   p <- read_package(
     system.file("extdata", "datapackage.json", package = "frictionless"),
-    quietly = TRUE
+    quiet = TRUE
   )
   dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
@@ -218,7 +218,7 @@ test_that("write_package() creates file for data = df in local package", {
   testthat::skip_if_offline()
   p <- read_package(
     system.file("extdata", "datapackage.json", package = "frictionless"),
-    quietly = TRUE
+    quiet = TRUE
   )
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
   p <- add_resource(p, "new", df)
@@ -312,6 +312,6 @@ test_that("write_package() will gzip file for compress = TRUE", {
   expect_false(file.exists(file.path(dir, "new.csv")))
 
   # Written file can be read by read_resource()
-  p_reread <- read_package(file.path(dir, "datapackage.json"), quietly = TRUE)
+  p_reread <- read_package(file.path(dir, "datapackage.json"), quiet = TRUE)
   expect_identical(read_resource(p_reread, "new"), dplyr::as_tibble(df))
 })

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -5,9 +5,8 @@ test_that("write_package() returns output Data Package (invisibly)", {
   dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
   p_written <- suppressMessages(write_package(p, dir))
-  p_from_file <- suppressMessages(read_package(
-    file.path(dir, "datapackage.json")
-  ))
+  p_from_file <-
+    read_package(file.path(dir, "datapackage.json"), quietly = TRUE)
   # p_from_file$directory will differ: overwrite to make the same
   p_from_file$directory <- p_written$directory
 
@@ -45,7 +44,7 @@ test_that("write_package() writes unaltered datapackage.json as is", {
   p_file <- system.file("extdata", "datapackage.json", package = "frictionless")
   json_original <- readr::read_lines(p_file) # Will use line endings of system
 
-  p <- suppressMessages(read_package(p_file))
+  p <- read_package(p_file, quietly = TRUE)
   dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
   suppressMessages(write_package(p, dir))
@@ -58,9 +57,10 @@ test_that("write_package() writes unaltered datapackage.json as is", {
 
 test_that("write_package() does not overwrite existing data files", {
   testthat::skip_if_offline()
-  p <- suppressMessages(read_package(
-    system.file("extdata", "datapackage.json", package = "frictionless")
-  ))
+  p <- read_package(
+    system.file("extdata", "datapackage.json", package = "frictionless"),
+    quietly = TRUE
+  )
   dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
   dir.create(dir)
@@ -84,9 +84,10 @@ test_that("write_package() does not overwrite existing data files", {
 
 test_that("write_package() copies file(s) for path = local in local package", {
   testthat::skip_if_offline()
-  p <- suppressMessages(read_package(
-    system.file("extdata", "datapackage.json", package = "frictionless")
-  ))
+  p <- read_package(
+    system.file("extdata", "datapackage.json", package = "frictionless"),
+    quietly = TRUE
+  )
   p$resources[[2]]$path[[2]] <- "observations_2.csv" # Make one URL a local path
   p <- add_resource(p, "new", test_path("data/df.csv"))
   dir <- file.path(tempdir(), "package")
@@ -139,9 +140,10 @@ test_that("write_package() downloads file(s) for path = local in remote
 
 test_that("write_package() leaves as is for path = URL in local package", {
   testthat::skip_if_offline()
-  p <- suppressMessages(read_package(
-    system.file("extdata", "datapackage.json", package = "frictionless")
-  ))
+  p <- read_package(
+    system.file("extdata", "datapackage.json", package = "frictionless"),
+    quietly = TRUE
+  )
   p <- add_resource(p, "new", file.path(
     "https://raw.githubusercontent.com/frictionlessdata/frictionless-r",
     "main/tests/testthat/data/df.csv"
@@ -183,9 +185,10 @@ test_that("write_package() leaves as is for path = URL in remote package", {
 
 test_that("write_package() leaves as is for data = json in local package", {
   testthat::skip_if_offline()
-  p <- suppressMessages(read_package(
-    system.file("extdata", "datapackage.json", package = "frictionless")
-  ))
+  p <- read_package(
+    system.file("extdata", "datapackage.json", package = "frictionless"),
+    quietly = TRUE
+  )
   dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
   p_written <- suppressMessages(write_package(p, dir))
@@ -213,9 +216,10 @@ test_that("write_package() leaves as is for data = json in remote package", {
 
 test_that("write_package() creates file for data = df in local package", {
   testthat::skip_if_offline()
-  p <- suppressMessages(read_package(
-    system.file("extdata", "datapackage.json", package = "frictionless")
-  ))
+  p <- read_package(
+    system.file("extdata", "datapackage.json", package = "frictionless"),
+    quietly = TRUE
+  )
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
   p <- add_resource(p, "new", df)
   dir <- file.path(tempdir(), "package")
@@ -308,6 +312,6 @@ test_that("write_package() will gzip file for compress = TRUE", {
   expect_false(file.exists(file.path(dir, "new.csv")))
 
   # Written file can be read by read_resource()
-  p_reread <- suppressMessages(read_package(file.path(dir, "datapackage.json")))
+  p_reread <- read_package(file.path(dir, "datapackage.json"), quietly = TRUE)
   expect_identical(read_resource(p_reread, "new"), dplyr::as_tibble(df))
 })


### PR DESCRIPTION


## Motivation
Resolves #121

It would be convenient at times to suppress the rights/citation reminder in read_package(), including in the tests internal to frictionless-r. This pull request implements a new argument to read_package(), changes the internal testing to take advantage of this new argument, and adds a simple test to see if the new argument works. 

## Changes


- [x] decide on argument name
- [x] add argument to read_package()
- [x] add coverage for new argument in test-read_package()
- [x] change existing tests to make use of new argument
- [ ] Should there be a version dump? 
- [ ] News.md