### PR TITLE
Add col_select parameter to read_resource()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/R/read_resource.R
+++ b/R/read_resource.R
@@ -326,6 +326,7 @@ read_resource <- function(package, resource_name, col_select = NULL) {
         ),
         col_names = col_names,
         col_types = col_types,
+        col_select = {{col_select}},
         locale = locale,
         na = replace_null(schema$missingValues, ""),
         comment = replace_null(dialect$commentChar, ""),

--- a/R/read_resource.R
+++ b/R/read_resource.R
@@ -177,6 +177,18 @@ read_resource <- function(package, resource_name, col_select = NULL) {
   schema <- get_schema(package, resource_name)
   fields <- schema$fields
 
+  # check if selected columns appear in schema
+  field_names <- purrr::map_chr(fields,~purrr::pluck(.x,"name"))
+  multiple_missing_columns <- sum(!col_select %in% field_names) > 1
+  assertthat::assert_that(
+    all(col_select %in% field_names),
+    msg = glue::glue(
+      "Can't find {ifelse(multiple_missing_columns,'columns','column')} ",
+      "`{paste(col_select[!col_select %in% field_names],collapse = '`, `')}` ",
+      "in schema"
+    )
+    )
+
   # Create locale with encoding, decimal_mark and grouping_mark
   encoding <- replace_null(resource$encoding, "UTF-8") # Set default to UTF-8
   if (!tolower(encoding) %in% tolower(iconvlist())) {

--- a/man/read_resource.Rd
+++ b/man/read_resource.Rd
@@ -4,54 +4,54 @@
 \alias{read_resource}
 \title{Read data from a Data Resource into a tibble data frame}
 \usage{
-read_resource(package, resource_name)
+read_resource(package, resource_name, col_select = NULL)
 }
 \arguments{
 \item{package}{List describing a Data Package, created with \code{\link[=read_package]{read_package()}}
 or \code{\link[=create_package]{create_package()}}.}
 
 \item{resource_name}{Name of the Data Resource.}
+
+\item{col_select}{Character vector of columns to include in the results.
+Columns will be provided in the same order as they are stated.}
 }
 \value{
 \code{\link[dplyr:reexports]{dplyr::tibble()}} data frame with the Data Resource's tabular data.
 }
 \description{
 Reads data from a \href{https://specs.frictionlessdata.io/data-resource/}{Data Resource} (in a Data
-Package) into a tibble (a Tidyverse data frame).
-The resource must be a \href{https://specs.frictionlessdata.io/tabular-data-resource/}{Tabular Data Resource}.
-The function uses \code{\link[readr:read_delim]{readr::read_delim()}} to read CSV files, passing the
-resource properties \code{path}, CSV dialect, column names, data types, etc.
-Column names are taken from the provided Table Schema (\code{schema}), not from
-the header in the CSV file(s).
+Package) into a tibble (a Tidyverse data frame). The resource must be a
+\href{https://specs.frictionlessdata.io/tabular-data-resource/}{Tabular Data Resource}. The
+function uses \code{\link[readr:read_delim]{readr::read_delim()}} to read CSV files, passing the resource
+properties \code{path}, CSV dialect, column names, data types, etc. Column names
+are taken from the provided Table Schema (\code{schema}), not from the header in
+the CSV file(s).
 }
 \section{Resource properties}{
-
-The \href{https://specs.frictionlessdata.io/data-resource/}{Data Resource properties} are handled as
-follows:
+ The \href{https://specs.frictionlessdata.io/data-resource/}{Data Resource properties} are handled
+as follows:
 \subsection{Path}{
 
 \href{https://specs.frictionlessdata.io/data-resource/#data-location}{\code{path}} is
-required.
-It can be a local path or URL, which must resolve.
-Absolute path (\code{/}) and relative parent path (\verb{../}) are forbidden to avoid
-security vulnerabilities.
+required. It can be a local path or URL, which must resolve. Absolute path
+(\code{/}) and relative parent path (\verb{../}) are forbidden to avoid security
+vulnerabilities.
 
-When multiple paths are provided (\verb{"path": [ "myfile1.csv", "myfile2.csv"]})
-then data are merged into a single data frame, in the order in which the
-paths are listed.
+When multiple paths are provided (\verb{"path": [ "myfile1.csv", "myfile2.csv"]}) then data are merged into a single data frame, in the
+order in which the paths are listed.
 }
 
 \subsection{Data}{
 
 If \code{path} is not present, the function will attempt to read data from the
-\code{data} property.
-\strong{\code{schema} will be ignored}.
+\code{data} property. \strong{\code{schema} will be ignored}.
 }
 
 \subsection{Name}{
 
-\code{name} is \href{https://specs.frictionlessdata.io/data-resource/#name}{required}.
-It is used to find the resource with \code{name} = \code{resource_name}.
+\code{name} is
+\href{https://specs.frictionlessdata.io/data-resource/#name}{required}. It is
+used to find the resource with \code{name} = \code{resource_name}.
 }
 
 \subsection{Profile}{
@@ -65,77 +65,60 @@ to have the value \code{tabular-data-resource}.
 
 \code{encoding} (e.g. \code{windows-1252}) is
 \href{https://specs.frictionlessdata.io/data-resource/#optional-properties}{required}
-if the resource file(s) is not encoded as UTF-8.
-The returned data frame will always be UTF-8.
+if the resource file(s) is not encoded as UTF-8. The returned data frame
+will always be UTF-8.
 }
 
 \subsection{CSV Dialect}{
 
 \code{dialect} properties are
 \href{https://specs.frictionlessdata.io/csv-dialect/#specification}{required} if
-the resource file(s) deviate from the default CSV settings (see below).
-It can either be a JSON object or a path or URL referencing a JSON object.
+the resource file(s) deviate from the default CSV settings (see below). It
+can either be a JSON object or a path or URL referencing a JSON object.
 Only deviating properties need to be specified, e.g. a tab delimited file
-without a header row needs:
+without a header row needs: \verb{json "dialect": \{"delimiter": "\\t", "header": "false"\} }
 
-\if{html}{\out{<div class="sourceCode json">}}\preformatted{"dialect": \{"delimiter": "\\t", "header": "false"\}
-}\if{html}{\out{</div>}}
-
-These are the CSV dialect properties.
-Some are ignored by the function:
-\itemize{
-\item \code{delimiter}: default \verb{,}.
-\item \code{lineTerminator}: ignored, line terminator characters \code{LF} and \code{CRLF} are
-interpreted automatically by \code{\link[readr:read_delim]{readr::read_delim()}}, while \code{CR} (used by
-Classic Mac OS, final release 2001) is not supported.
-\item \code{doubleQuote}: default \code{true}.
-\item \code{quoteChar}: default \verb{"}.
-\item \code{escapeChar}: anything but \verb{\\} is ignored and it will set \code{doubleQuote} to
-\code{false} as these fields are mutually exclusive.
-You can thus not escape with \verb{\\"} and \code{""} in the same file.
-\item \code{nullSequence}: ignored, use \code{missingValues}.
-\item \code{skipInitialSpace}: default \code{false}.
-\item \code{header}: default \code{true}.
-\item \code{commentChar}: not set by default.
-\item \code{caseSensitiveHeader}: ignored, header is not used for column names, see
-Schema.
-\item \code{csvddfVersion}: ignored.
-}
+These are the CSV dialect properties. Some are ignored by the function: -
+\code{delimiter}: default \verb{,}. - \code{lineTerminator}: ignored, line terminator
+characters \code{LF} and \code{CRLF} are interpreted automatically by
+\code{\link[readr:read_delim]{readr::read_delim()}}, while \code{CR} (used by Classic Mac OS, final release
+2001) is not supported. - \code{doubleQuote}: default \code{true}. - \code{quoteChar}:
+default \verb{"}. - \code{escapeChar}: anything but \verb{\\} is ignored and it will set
+\code{doubleQuote} to \code{false} as these fields are mutually exclusive. You can
+thus not escape with \verb{\\"} and \code{""} in the same file. - \code{nullSequence}:
+ignored, use \code{missingValues}. - \code{skipInitialSpace}: default \code{false}. -
+\code{header}: default \code{true}. - \code{commentChar}: not set by default. -
+\code{caseSensitiveHeader}: ignored, header is not used for column names, see
+Schema. - \code{csvddfVersion}: ignored.
 }
 
 \subsection{File compression}{
 
 Resource file(s) with \code{path} ending in \code{.gz}, \code{.bz2}, \code{.xz}, or \code{.zip} are
 automatically decompressed using default \code{\link[readr:read_delim]{readr::read_delim()}}
-functionality.
-Only \code{.gz} files can be read directly from URL \code{path}s.
-Only the extension in \code{path} can be used to indicate compression type,
-the \code{compression} property is
+functionality. Only \code{.gz} files can be read directly from URL \code{path}s. Only
+the extension in \code{path} can be used to indicate compression type, the
+\code{compression} property is
 \href{https://specs.frictionlessdata.io/patterns/#specification-3}{ignored}.
 }
 
 \subsection{Ignored resource properties}{
 \itemize{
-\item \code{title}
-\item \code{description}
-\item \code{format}
-\item \code{mediatype}
-\item \code{bytes}
-\item \code{hash}
-\item \code{sources}
-\item \code{licenses}
+\item \code{title} - \code{description} - \code{format} - \code{mediatype} - \code{bytes} - \code{hash} -
+\code{sources} - \code{licenses}
 }
 }
 }
 
 \section{Table schema properties}{
-
-\code{schema} is required and must follow the \href{https://specs.frictionlessdata.io/table-schema/}{Table Schema} specification.
-It can either be a JSON object or a path or URL referencing a JSON object.
+ \code{schema} is required and must follow the
+\href{https://specs.frictionlessdata.io/table-schema/}{Table Schema}
+specification. It can either be a JSON object or a path or URL referencing
+a JSON object.
 \itemize{
-\item Field \code{name}s are used as column headers.
-\item Field \code{type}s are use as column types (see further).
-\item \href{https://specs.frictionlessdata.io/table-schema/#missing-values}{\code{missingValues}}
+\item Field \code{name}s are used as column headers. - Field \code{type}s are use as
+column types (see further). -
+\href{https://specs.frictionlessdata.io/table-schema/#missing-values}{\code{missingValues}}
 are used to interpret as \code{NA}, with \code{""} as default.
 }
 \subsection{Field types}{
@@ -143,55 +126,46 @@ are used to interpret as \code{NA}, with \code{""} as default.
 Field \code{type} is used to set the column type, as follows:
 \itemize{
 \item \href{https://specs.frictionlessdata.io/table-schema/#string}{string} as
-\code{character}; or \code{factor} when \code{enum} is present.
-\code{format} is ignored.
-\item \href{https://specs.frictionlessdata.io/table-schema/#number}{number} as
-\code{double}; or \code{factor} when \code{enum} is present.
-Use \code{bareNumber: false} to ignore whitespace and non-numeric characters.
-\code{decimalChar} (\code{.} by default) and \code{groupChar} (undefined by default) can
-be defined, but the most occurring value will be used as a global value for
-all number fields of that resource.
-\item \href{https://specs.frictionlessdata.io/table-schema/#integer}{integer} as
+\code{character}; or \code{factor} when \code{enum} is present. \code{format} is ignored. -
+\href{https://specs.frictionlessdata.io/table-schema/#number}{number} as
+\code{double}; or \code{factor} when \code{enum} is present. Use \code{bareNumber: false} to
+ignore whitespace and non-numeric characters. \code{decimalChar} (\code{.} by
+default) and \code{groupChar} (undefined by default) can be defined, but the
+most occurring value will be used as a global value for all number fields
+of that resource. -
+\href{https://specs.frictionlessdata.io/table-schema/#integer}{integer} as
 \code{double} (not integer, to avoid issues with big numbers); or \code{factor} when
-\code{enum} is present.
-Use \code{bareNumber: false} to ignore whitespace and non-numeric characters.
-\item \href{https://specs.frictionlessdata.io/table-schema/#boolean}{boolean} as
-\code{logical}.
-Non-default \code{trueValues/falseValues} are not supported.
-\item \href{https://specs.frictionlessdata.io/table-schema/#object}{object} as
-\code{character}.
-\item \href{https://specs.frictionlessdata.io/table-schema/#array}{array} as
-\code{character}.
-\item \href{https://specs.frictionlessdata.io/table-schema/#date}{date} as \code{date}.
-Supports \code{format}, with values \code{default} (ISO date), \code{any} (guess \code{ymd})
-and \href{https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior}{Python/C strptime}
-patterns, such as \verb{\%a, \%d \%B \%Y} for \verb{Sat, 23 November 2013}.
-\verb{\%x} is \verb{\%m/\%d/\%y}.
-\verb{\%j}, \verb{\%U}, \verb{\%w} and \verb{\%W} are not supported.
-\item \href{https://specs.frictionlessdata.io/table-schema/#time}{time} as
-\code{\link[hms:hms]{hms::hms()}}.
-Supports \code{format}, with values \code{default} (ISO time), \code{any} (guess \code{hms})
-and \href{https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior}{Python/C strptime}
-patterns, such as \verb{\%I\%p\%M:\%S.\%f\%z} for \verb{8AM30:00.300+0200}.
-\item \href{https://specs.frictionlessdata.io/table-schema/#datetime}{datetime} as
-\code{POSIXct}.
-Supports \code{format}, with values \code{default} (ISO datetime), \code{any}
-(ISO datetime) and the same patterns as for \code{date} and \code{time}.
-\verb{\%c} is not supported.
-\item \href{https://specs.frictionlessdata.io/table-schema/#year}{year} as \code{date},
-with \code{01} for month and day.
-\item \href{https://specs.frictionlessdata.io/table-schema/#yearmonth}{yearmonth} as
-\code{date}, with \code{01} for day.
-\item \href{https://specs.frictionlessdata.io/table-schema/#duration}{duration} as
-\code{character}.
-Can be parsed afterwards with \code{\link[lubridate:duration]{lubridate::duration()}}.
-\item \href{https://specs.frictionlessdata.io/table-schema/#geopoint}{geopoint} as
-\code{character}.
-\item \href{https://specs.frictionlessdata.io/table-schema/#geojson}{geojson} as
-\code{character}.
-\item \href{https://specs.frictionlessdata.io/table-schema/#any}{any} as \code{character}.
-\item Any other value is not allowed.
-\item Type is guessed when not provided.
+\code{enum} is present. Use \code{bareNumber: false} to ignore whitespace and
+non-numeric characters. -
+\href{https://specs.frictionlessdata.io/table-schema/#boolean}{boolean} as
+\code{logical}. Non-default \code{trueValues/falseValues} are not supported. -
+\href{https://specs.frictionlessdata.io/table-schema/#object}{object} as
+\code{character}. -
+\href{https://specs.frictionlessdata.io/table-schema/#array}{array} as
+\code{character}. - \href{https://specs.frictionlessdata.io/table-schema/#date}{date}
+as \code{date}. Supports \code{format}, with values \code{default} (ISO date), \code{any}
+(guess \code{ymd}) and \href{https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior}{Python/C strptime}
+patterns, such as \verb{\%a, \%d \%B \%Y} for \verb{Sat, 23 November 2013}. \verb{\%x} is
+\verb{\%m/\%d/\%y}. \verb{\%j}, \verb{\%U}, \verb{\%w} and \verb{\%W} are not supported. -
+\href{https://specs.frictionlessdata.io/table-schema/#time}{time} as
+\code{\link[hms:hms]{hms::hms()}}. Supports \code{format}, with values \code{default} (ISO time), \code{any}
+(guess \code{hms}) and \href{https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior}{Python/C strptime}
+patterns, such as \verb{\%I\%p\%M:\%S.\%f\%z} for \verb{8AM30:00.300+0200}. -
+\href{https://specs.frictionlessdata.io/table-schema/#datetime}{datetime} as
+\code{POSIXct}. Supports \code{format}, with values \code{default} (ISO datetime), \code{any}
+(ISO datetime) and the same patterns as for \code{date} and \code{time}. \verb{\%c} is not
+supported. - \href{https://specs.frictionlessdata.io/table-schema/#year}{year}
+as \code{date}, with \code{01} for month and day. -
+\href{https://specs.frictionlessdata.io/table-schema/#yearmonth}{yearmonth} as
+\code{date}, with \code{01} for day. -
+\href{https://specs.frictionlessdata.io/table-schema/#duration}{duration} as
+\code{character}. Can be parsed afterwards with \code{\link[lubridate:duration]{lubridate::duration()}}. -
+\href{https://specs.frictionlessdata.io/table-schema/#geopoint}{geopoint} as
+\code{character}. -
+\href{https://specs.frictionlessdata.io/table-schema/#geojson}{geojson} as
+\code{character}. - \href{https://specs.frictionlessdata.io/table-schema/#any}{any}
+as \code{character}. - Any other value is not allowed. - Type is guessed when
+not provided.
 }
 }
 }

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -1,6 +1,5 @@
 test_that("read_resource() returns a tibble", {
-  testthat::skip_if_offline()
-  p <- example_package
+
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
   p <- add_resource(p, "new", df)
 
@@ -661,4 +660,33 @@ test_that("read_resource() handles other types", {
 
   # Guess undefined types, unknown types are blocked by check_schema()
   expect_type(resource$no_type, "logical")
+})
+
+test_that("read_resource() allows selecting of resource columns", {
+  # single column
+  expect_named(
+    read_resource(example_package,
+                  "observations",
+                  col_select = "observation_id"),
+    "observation_id")
+  # multiple columns
+  expect_named(
+    read_resource(
+      example_package,
+      "observations",
+      col_select = c("observation_id", "deployment_id")
+    ),
+    c(
+      "observation_id",
+      "deployment_id"
+    )
+  )
+  # different order
+  expect_named(
+    read_resource(example_package,
+                  "observations",
+                  col_select = c("observation_id","deployment_id","media_id")),
+    c("observation_id","deployment_id","media_id"),
+    ignore.order = FALSE
+  )
 })

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -1,5 +1,6 @@
 test_that("read_resource() returns a tibble", {
-
+  testthat::skip_if_offline()
+  p <- example_package
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
   p <- add_resource(p, "new", df)
 
@@ -685,8 +686,8 @@ test_that("read_resource() allows selecting of resource columns", {
   expect_named(
     read_resource(example_package,
                   "observations",
-                  col_select = c("observation_id","deployment_id","media_id")),
-    c("observation_id","deployment_id","media_id"),
+                  col_select = c("observation_id","scientific_name","deployment_id")),
+    c("observation_id","scientific_name","deployment_id"),
     ignore.order = FALSE
   )
 })

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -698,15 +698,19 @@ test_that("read_resource() returns error on column select outside schema", {
   expect_error(
     read_resource(example_package,
                   resource_to_read,
-                  col_select = not_a_column)#,
-    # regexp = glue::glue("{not_a_column} not found in {resource_to_read} schema"),
-    # fixed = TRUE
+                  col_select = not_a_column),
+    regexp = glue::glue("Can't find column `{not_a_column}` in schema"),
+    fixed = TRUE
   )
 
   expect_error(
-    read_resource(example_package,
-                  resource_to_read,
-                  col_select = "not_a_column","timestamp","also_not_a_column")
+    read_resource(
+      example_package,
+      resource_to_read,
+      col_select = c("not_a_column", "timestamp", "also_not_a_column")
+    ),
+    regexp = "Can't find columns `not_a_column`, `also_not_a_column` in schema",
+    fixed = TRUE
   )
 
   expect_no_error(

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -698,9 +698,22 @@ test_that("read_resource() returns error on column select outside schema", {
   expect_error(
     read_resource(example_package,
                   resource_to_read,
-                  col_select = not_a_column),
-    regexp = glue::glue("{not_a_column} not found in {resource_to_read} schema"),
-    fixed = TRUE
+                  col_select = not_a_column)#,
+    # regexp = glue::glue("{not_a_column} not found in {resource_to_read} schema"),
+    # fixed = TRUE
+  )
+
+  expect_error(
+    read_resource(example_package,
+                  resource_to_read,
+                  col_select = "not_a_column","timestamp","also_not_a_column")
+  )
+
+  expect_no_error(
+    read_resource(example_package,
+                  resource_to_read,
+                  col_select = c("media_id","timestamp","observation_id")
+    )
   )
 })
 

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -690,3 +690,16 @@ test_that("read_resource() allows selecting of resource columns", {
     ignore.order = FALSE
   )
 })
+
+test_that("read_resource() returns error on column select outside schema", {
+  not_a_column <- "this is not a valid column name!"
+  resource_to_read <- "media"
+  expect_error(
+    read_resource(example_package,
+                  resource_to_read,
+                  col_select = not_a_column),
+    regexp = glue::glue("{not_a_column} not found in {resource_to_read} schema"),
+    fixed = TRUE
+  )
+})
+


### PR DESCRIPTION
Resolves #123:

> [read_delim()](https://readr.tidyverse.org/reference/read_delim.html) has a col_select parameter that allows to select columns before reading data. This can vastly improve read speed: I think read_resource() should also allow this.

See #123 for details 

Changes should be non breaking. 

---

I suggest a version bump 

