### PR TITLE
add explicit default simplifyVector=T on fromJSON call

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -132,7 +132,7 @@ read_descriptor <- function(x, directory = NULL, safe = FALSE) {
       x <- yaml::yaml.load_file(x)
     } else {
       # Default to jsonlite: better error messages for non .json files
-      x <- jsonlite::fromJSON(x, simplifyDataFrame = FALSE)
+      x <- jsonlite::fromJSON(x, simplifyDataFrame = FALSE, simplifyVector = TRUE)
     }
   }
   return(x)


### PR DESCRIPTION
Hi @peterdesmet, this PR is cosmetic only, and just makes a default parameter value explicit. I actually needed this to be `FALSE` for some of my deposits work, so followed through why you use the default `TRUE` here. Your reason for that now makes sense to me, but having it explicitly here would have helped my initial reading of the code.