### PR TITLE
Add curl to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Imports:
     utils,
     yaml
 Suggests:
+    curl,
     hms,
     knitr,
     lubridate,


### PR DESCRIPTION
Reported on rOpenSci slack that if `skip_if_offline()` is used, `curl` needs to be added to `suggests`, otherwise those tests are just ignored on GitHub Actions.