### PR TITLE
🔗 Fix link to `datapackages-r`

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -93,7 +93,7 @@ For more functionality, see [get started](https://docs.ropensci.org/frictionless
 
 ## frictionless vs datapackage.r
 
-[datapackage.r](https://CRAN.R-project.org/package=datapackage.r) is an alternative R package to work with Data Packages. It has an object-oriented design (using a `Package` class) and offers validation. frictionless on the other hand allows you to quickly read and write Data Packages to and from data frames, getting out of the way for the rest of your analysis. It is designed to be lightweight, follows [tidyverse](https://www.tidyverse.org/) principles and supports piping.
+[datapackage.r](https://github.com/frictionlessdata/datapackage-r) is an alternative R package to work with Data Packages. It has an object-oriented design (using a `Package` class) and offers validation. frictionless on the other hand allows you to quickly read and write Data Packages to and from data frames, getting out of the way for the rest of your analysis. It is designed to be lightweight, follows [tidyverse](https://www.tidyverse.org/) principles and supports piping.
 
 ## Meta
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ container format and standard to describe and package a collection of
 
 To get started, see:
 
--   [Get
-    started](https://docs.ropensci.org/frictionless/articles/frictionless.html):
-    an introduction to the package’s main functionalities.
--   [Function
-    reference](https://docs.ropensci.org/frictionless/reference/index.html):
-    overview of all functions.
+- [Get
+  started](https://docs.ropensci.org/frictionless/articles/frictionless.html):
+  an introduction to the package’s main functionalities.
+- [Function
+  reference](https://docs.ropensci.org/frictionless/reference/index.html):
+  overview of all functions.
 
 ## Installation
 
@@ -80,25 +80,25 @@ resources(package)
 # multiple zipped CSV files.
 read_resource(package, "gps")
 #> # A tibble: 73,047 × 21
-#>    event-i…¹ visible timestamp           locat…² locat…³ bar:b…⁴ exter…⁵ gps:d…⁶
-#>        <dbl> <lgl>   <dttm>                <dbl>   <dbl>   <dbl>   <dbl>   <dbl>
-#>  1   1.43e10 TRUE    2018-05-25 16:11:37    4.25    51.3      NA    32.5     2  
-#>  2   1.43e10 TRUE    2018-05-25 16:16:41    4.25    51.3      NA    32.8     2.1
-#>  3   1.43e10 TRUE    2018-05-25 16:21:29    4.25    51.3      NA    34.1     2.1
-#>  4   1.43e10 TRUE    2018-05-25 16:26:28    4.25    51.3      NA    34.5     2.2
-#>  5   1.43e10 TRUE    2018-05-25 16:31:21    4.25    51.3      NA    34.1     2.2
-#>  6   1.43e10 TRUE    2018-05-25 16:36:09    4.25    51.3      NA    32.5     2.2
-#>  7   1.43e10 TRUE    2018-05-25 16:40:57    4.25    51.3      NA    32.1     2.2
-#>  8   1.43e10 TRUE    2018-05-25 16:45:55    4.25    51.3      NA    33.3     2.1
-#>  9   1.43e10 TRUE    2018-05-25 16:50:49    4.25    51.3      NA    32.6     2.1
-#> 10   1.43e10 TRUE    2018-05-25 16:55:36    4.25    51.3      NA    31.7     2  
-#> # … with 73,037 more rows, 13 more variables: `gps:satellite-count` <dbl>,
+#>     `event-id` visible timestamp           `location-long` `location-lat`
+#>          <dbl> <lgl>   <dttm>                        <dbl>          <dbl>
+#>  1 14256075762 TRUE    2018-05-25 16:11:37            4.25           51.3
+#>  2 14256075763 TRUE    2018-05-25 16:16:41            4.25           51.3
+#>  3 14256075764 TRUE    2018-05-25 16:21:29            4.25           51.3
+#>  4 14256075765 TRUE    2018-05-25 16:26:28            4.25           51.3
+#>  5 14256075766 TRUE    2018-05-25 16:31:21            4.25           51.3
+#>  6 14256075767 TRUE    2018-05-25 16:36:09            4.25           51.3
+#>  7 14256075768 TRUE    2018-05-25 16:40:57            4.25           51.3
+#>  8 14256075769 TRUE    2018-05-25 16:45:55            4.25           51.3
+#>  9 14256075770 TRUE    2018-05-25 16:50:49            4.25           51.3
+#> 10 14256075771 TRUE    2018-05-25 16:55:36            4.25           51.3
+#> # ℹ 73,037 more rows
+#> # ℹ 16 more variables: `bar:barometric-pressure` <dbl>,
+#> #   `external-temperature` <dbl>, `gps:dop` <dbl>, `gps:satellite-count` <dbl>,
 #> #   `gps-time-to-fix` <dbl>, `ground-speed` <dbl>, heading <dbl>,
 #> #   `height-above-msl` <dbl>, `location-error-numerical` <dbl>,
 #> #   `manually-marked-outlier` <lgl>, `vertical-error-numerical` <dbl>,
-#> #   `sensor-type` <chr>, `individual-taxon-canonical-name` <chr>,
-#> #   `tag-local-identifier` <chr>, `individual-local-identifier` <chr>,
-#> #   `study-name` <chr>, and abbreviated variable names ¹​`event-id`, …
+#> #   `sensor-type` <chr>, `individual-taxon-canonical-name` <chr>, …
 ```
 
 You can also create your own Data Package, add data and **write** it to
@@ -122,7 +122,7 @@ reference](https://docs.ropensci.org/frictionless/reference/index.html).
 
 ## frictionless vs datapackage.r
 
-[datapackage-r](https://github.com/frictionlessdata/datapackage-r) is an
+[datapackage.r](https://github.com/frictionlessdata/datapackage-r) is an
 alternative R package to work with Data Packages. It has an
 object-oriented design (using a `Package` class) and offers validation.
 frictionless on the other hand allows you to quickly read and write Data
@@ -132,14 +132,13 @@ your analysis. It is designed to be lightweight, follows
 
 ## Meta
 
--   We welcome
-    [contributions](https://docs.ropensci.org/frictionless/CONTRIBUTING.html)
-    including bug reports.
--   License: MIT
--   Get [citation
-    information](https://docs.ropensci.org/frictionless/authors.html#citation)
-    for frictionless in R doing `citation("frictionless")`.
--   Please note that this project is released with a [Contributor Code
-    of
-    Conduct](https://frictionlessdata.io/work-with-us/code-of-conduct/).
-    By participating in this project you agree to abide by its terms.
+- We welcome
+  [contributions](https://docs.ropensci.org/frictionless/CONTRIBUTING.html)
+  including bug reports.
+- License: MIT
+- Get [citation
+  information](https://docs.ropensci.org/frictionless/authors.html#citation)
+  for frictionless in R doing `citation("frictionless")`.
+- Please note that this project is released with a [Contributor Code of
+  Conduct](https://frictionlessdata.io/work-with-us/code-of-conduct/).
+  By participating in this project you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ reference](https://docs.ropensci.org/frictionless/reference/index.html).
 
 ## frictionless vs datapackage.r
 
-[datapackage.r](https://CRAN.R-project.org/package=datapackage.r) is an
+[datapackage-r](https://github.com/frictionlessdata/datapackage-r) is an
 alternative R package to work with Data Packages. It has an
 object-oriented design (using a `Package` class) and offers validation.
 frictionless on the other hand allows you to quickly read and write Data


### PR DESCRIPTION
The link to `datapackages.r` is broken. 

This new link refers to a repository `datapackages-r` from the **frictionlessdata** organization.