### PR TITLE
Use CLI for `check_path()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ URL: https://github.com/frictionlessdata/frictionless-r,
 BugReports: https://github.com/frictionlessdata/frictionless-r/issues
 Imports:
     assertthat,
+    cli,
     dplyr,
     glue,
     httr,

--- a/R/check_path.R
+++ b/R/check_path.R
@@ -1,0 +1,48 @@
+#' Check path or URL
+#'
+#' Check if a [path or
+#' URL](https://specs.frictionlessdata.io/data-resource/#url-or-path) is valid
+#' (and optionally safe) and prepend with directory to create an absolute path
+#' or URL.
+#' Returns error when no file can be found.
+#'
+#' @param path Path or URL to a file.
+#' @param directory Directory to prepend to path.
+#' @param safe Require `path` to be safe, i.e. no absolute or relative parent
+#'   paths.
+#' @return Absolute path or URL.
+#' @family helper functions
+#' @noRd
+check_path <- function(path, directory = NULL, safe = FALSE) {
+  # Check that (non-URL) path is safe and prepend with directory to make
+  # absolute path (both optional)
+  if (!is_url(path)) {
+    assertthat::assert_that(
+      !safe | !startsWith(path, "/"),
+      msg = glue::glue("`{path}` is an absolute path (`/`) which is unsafe.")
+    )
+    assertthat::assert_that(
+      !safe | !startsWith(path, "../"),
+      msg = glue::glue(
+        "`{path}` is a relative parent path (`../`) which is unsafe."
+      )
+    )
+    if (!is.null(directory)) {
+      path <- paste(directory, path, sep = "/")
+    }
+  }
+
+  # Check existence of file at path
+  if (is_url(path)) {
+    assertthat::assert_that(
+      !httr::http_error(path),
+      msg = glue::glue("Can't find file at `{path}`.")
+    )
+  } else {
+    assertthat::assert_that(
+      file.exists(path),
+      msg = glue::glue("Can't find file at `{path}`.")
+    )
+  }
+  return(path)
+}

--- a/R/check_path.R
+++ b/R/check_path.R
@@ -14,35 +14,41 @@
 #' @family helper functions
 #' @noRd
 check_path <- function(path, directory = NULL, safe = FALSE) {
-  # Check that (non-URL) path is safe and prepend with directory to make
-  # absolute path (both optional)
+  # Process path
   if (!is_url(path)) {
-    assertthat::assert_that(
-      !safe | !startsWith(path, "/"),
-      msg = glue::glue("`{path}` is an absolute path (`/`) which is unsafe.")
-    )
-    assertthat::assert_that(
-      !safe | !startsWith(path, "../"),
-      msg = glue::glue(
-        "`{path}` is a relative parent path (`../`) which is unsafe."
-      )
-    )
-    if (!is.null(directory)) {
-      path <- paste(directory, path, sep = "/")
+    # Check absolute path
+    if (safe && startsWith(path, "/")) {
+      cli::cli_abort(c(
+        "{.arg path} must be a safe path.",
+        "x" = "{.path {path}} is an absolute path starting with {.val /} which
+               is unsafe."
+      ))
+    }
+
+    # Check relative path
+    if (safe && startsWith(path, "../")) {
+      cli::cli_abort(c(
+        "{.arg path} must be a safe path.",
+        "x" = "{.path {path}} is a relative parent path starting with {.val ../}
+               which is unsafe."
+      ))
+    }
+
+    # Prepend with directory (which can be a URL)
+    if (!is_url(path) && !is.null(directory)) {
+      path <- file.path(directory, path)
     }
   }
 
   # Check existence of file at path
   if (is_url(path)) {
-    assertthat::assert_that(
-      !httr::http_error(path),
-      msg = glue::glue("Can't find file at `{path}`.")
-    )
+    if (httr::http_error(path)) {
+      cli::cli_abort("Can't find file at {.url {path}}.")
+    }
   } else {
-    assertthat::assert_that(
-      file.exists(path),
-      msg = glue::glue("Can't find file at `{path}`.")
-    )
+    if (!file.exists(path)) {
+      cli::cli_abort("Can't find file at {.path {path}}.")
+    }
   }
   return(path)
 }

--- a/R/check_path.R
+++ b/R/check_path.R
@@ -18,20 +18,26 @@ check_path <- function(path, directory = NULL, safe = FALSE) {
   if (!is_url(path)) {
     # Check absolute path
     if (safe && startsWith(path, "/")) {
-      cli::cli_abort(c(
-        "{.arg path} must be a safe path.",
-        "x" = "{.path {path}} is an absolute path starting with {.val /} which
-               is unsafe."
-      ))
+      cli::cli_abort(
+        c(
+          "{.arg path} must be a safe path.",
+          "x" = "{.path {path}} is an absolute path starting with {.val /}
+                 which is unsafe."
+        ),
+        class = "frictionless_error_unsafe_absolute_path"
+      )
     }
 
     # Check relative path
     if (safe && startsWith(path, "../")) {
-      cli::cli_abort(c(
-        "{.arg path} must be a safe path.",
-        "x" = "{.path {path}} is a relative parent path starting with {.val ../}
-               which is unsafe."
-      ))
+      cli::cli_abort(
+        c(
+          "{.arg path} must be a safe path.",
+          "x" = "{.path {path}} is a relative parent path starting with
+                 {.val ../} which is unsafe."
+        ),
+        class = "frictionless_error_unsafe_relative_path"
+      )
     }
 
     # Prepend with directory (which can be a URL)
@@ -43,11 +49,17 @@ check_path <- function(path, directory = NULL, safe = FALSE) {
   # Check existence of file at path
   if (is_url(path)) {
     if (httr::http_error(path)) {
-      cli::cli_abort("Can't find file at {.url {path}}.")
+      cli::cli_abort(
+        "Can't find file at {.url {path}}.",
+        class = "frictionless_error_not_found_url"
+      )
     }
   } else {
     if (!file.exists(path)) {
-      cli::cli_abort("Can't find file at {.path {path}}.")
+      cli::cli_abort(
+        "Can't find file at {.path {path}}.",
+        class = "frictionless_error_not_found_path"
+      )
     }
   }
   return(path)

--- a/R/check_path.R
+++ b/R/check_path.R
@@ -24,7 +24,7 @@ check_path <- function(path, directory = NULL, safe = FALSE) {
           "x" = "{.path {path}} is an absolute path starting with {.val /}
                  which is unsafe."
         ),
-        class = "frictionless_error_unsafe_absolute_path"
+        class = "frictionless_error_path_unsafe_absolute"
       )
     }
 
@@ -36,7 +36,7 @@ check_path <- function(path, directory = NULL, safe = FALSE) {
           "x" = "{.path {path}} is a relative parent path starting with
                  {.val ../} which is unsafe."
         ),
-        class = "frictionless_error_unsafe_relative_path"
+        class = "frictionless_error_path_unsafe_relative"
       )
     }
 
@@ -51,14 +51,14 @@ check_path <- function(path, directory = NULL, safe = FALSE) {
     if (httr::http_error(path)) {
       cli::cli_abort(
         "Can't find file at {.url {path}}.",
-        class = "frictionless_error_not_found_url"
+        class = "frictionless_error_url_not_found"
       )
     }
   } else {
     if (!file.exists(path)) {
       cli::cli_abort(
         "Can't find file at {.path {path}}.",
-        class = "frictionless_error_not_found_path"
+        class = "frictionless_error_path_not_found"
       )
     }
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -68,55 +68,6 @@ is_url <- function(path) {
   grepl("^(http|https|ftp|ftps|sftp):\\/\\/", path)
 }
 
-#' Check path or URL
-#'
-#' Check if a [path or
-#' URL](https://specs.frictionlessdata.io/data-resource/#url-or-path) is valid
-#' (and optionally safe) and prepend with directory to create an absolute path
-#' or URL.
-#' Returns error when no file can be found.
-#'
-#' @param path Path or URL to a file.
-#' @param directory Directory to prepend to path.
-#' @param safe Require `path` to be safe, i.e. no absolute or relative parent
-#'   paths.
-#' @return Absolute path or URL.
-#' @family helper functions
-#' @noRd
-check_path <- function(path, directory = NULL, safe = FALSE) {
-  # Check that (non-URL) path is safe and prepend with directory to make
-  # absolute path (both optional)
-  if (!is_url(path)) {
-    assertthat::assert_that(
-      !safe | !startsWith(path, "/"),
-      msg = glue::glue("`{path}` is an absolute path (`/`) which is unsafe.")
-    )
-    assertthat::assert_that(
-      !safe | !startsWith(path, "../"),
-      msg = glue::glue(
-        "`{path}` is a relative parent path (`../`) which is unsafe."
-      )
-    )
-    if (!is.null(directory)) {
-      path <- paste(directory, path, sep = "/")
-    }
-  }
-
-  # Check existence of file at path
-  if (is_url(path)) {
-    assertthat::assert_that(
-      !httr::http_error(path),
-      msg = glue::glue("Can't find file at `{path}`.")
-    )
-  } else {
-    assertthat::assert_that(
-      file.exists(path),
-      msg = glue::glue("Can't find file at `{path}`.")
-    )
-  }
-  return(path)
-}
-
 #' Read descriptor
 #'
 #' Returns descriptor `x` as is, or attempts to read JSON/YAML from path or URL.

--- a/tests/testthat/test-add_resource.R
+++ b/tests/testthat/test-add_resource.R
@@ -94,32 +94,32 @@ test_that("add_resource() returns error if CSV file cannot be found", {
   schema <- create_schema(data.frame("col_1" = c(1, 2), "col_2" = c("a", "b")))
   expect_error(
     add_resource(p, "new", "no_such_file.csv"),
-    "Can't find file at `no_such_file.csv`.",
+    "Can't find file at 'no_such_file.csv'.",
     fixed = TRUE
   )
   expect_error(
     add_resource(p, "new", "no_such_file.csv", schema),
-    "Can't find file at `no_such_file.csv`.",
+    "Can't find file at 'no_such_file.csv'.",
     fixed = TRUE
   )
   expect_error(
     add_resource(p, "new", c(df_csv, "no_such_file.csv")),
-    "Can't find file at `no_such_file.csv`.",
+    "Can't find file at 'no_such_file.csv'.",
     fixed = TRUE
   )
   expect_error(
     add_resource(p, "new", c("no_such_file.csv", df_csv)),
-    "Can't find file at `no_such_file.csv`.",
+    "Can't find file at 'no_such_file.csv'.",
     fixed = TRUE
   )
   expect_error(
     add_resource(p, "new", c("no_such_file_1.csv", "no_such_file_2.csv")),
-    "Can't find file at `no_such_file_1.csv`.",
+    "Can't find file at 'no_such_file_1.csv'.",
     fixed = TRUE
   )
   expect_error(
     add_resource(p, "new", "http://example.com/no_such_file.csv"),
-    "Can't find file at `http://example.com/no_such_file.csv`.",
+    "Can't find file at <http://example.com/no_such_file.csv>.",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-add_resource.R
+++ b/tests/testthat/test-add_resource.R
@@ -94,33 +94,27 @@ test_that("add_resource() returns error if CSV file cannot be found", {
   schema <- create_schema(data.frame("col_1" = c(1, 2), "col_2" = c("a", "b")))
   expect_error(
     add_resource(p, "new", "no_such_file.csv"),
-    "Can't find file at 'no_such_file.csv'.",
-    fixed = TRUE
+    class = "frictionless_error_not_found_path"
   )
   expect_error(
     add_resource(p, "new", "no_such_file.csv", schema),
-    "Can't find file at 'no_such_file.csv'.",
-    fixed = TRUE
+    class = "frictionless_error_not_found_path"
   )
   expect_error(
     add_resource(p, "new", c(df_csv, "no_such_file.csv")),
-    "Can't find file at 'no_such_file.csv'.",
-    fixed = TRUE
+    class = "frictionless_error_not_found_path"
   )
   expect_error(
     add_resource(p, "new", c("no_such_file.csv", df_csv)),
-    "Can't find file at 'no_such_file.csv'.",
-    fixed = TRUE
+    class = "frictionless_error_not_found_path"
   )
   expect_error(
     add_resource(p, "new", c("no_such_file_1.csv", "no_such_file_2.csv")),
-    "Can't find file at 'no_such_file_1.csv'.",
-    fixed = TRUE
+    class = "frictionless_error_not_found_path"
   )
   expect_error(
     add_resource(p, "new", "http://example.com/no_such_file.csv"),
-    "Can't find file at <http://example.com/no_such_file.csv>.",
-    fixed = TRUE
+    class = "frictionless_error_not_found_url"
   )
 })
 

--- a/tests/testthat/test-add_resource.R
+++ b/tests/testthat/test-add_resource.R
@@ -94,27 +94,27 @@ test_that("add_resource() returns error if CSV file cannot be found", {
   schema <- create_schema(data.frame("col_1" = c(1, 2), "col_2" = c("a", "b")))
   expect_error(
     add_resource(p, "new", "no_such_file.csv"),
-    class = "frictionless_error_not_found_path"
+    class = "frictionless_error_path_not_found"
   )
   expect_error(
     add_resource(p, "new", "no_such_file.csv", schema),
-    class = "frictionless_error_not_found_path"
+    class = "frictionless_error_path_not_found"
   )
   expect_error(
     add_resource(p, "new", c(df_csv, "no_such_file.csv")),
-    class = "frictionless_error_not_found_path"
+    class = "frictionless_error_path_not_found"
   )
   expect_error(
     add_resource(p, "new", c("no_such_file.csv", df_csv)),
-    class = "frictionless_error_not_found_path"
+    class = "frictionless_error_path_not_found"
   )
   expect_error(
     add_resource(p, "new", c("no_such_file_1.csv", "no_such_file_2.csv")),
-    class = "frictionless_error_not_found_path"
+    class = "frictionless_error_path_not_found"
   )
   expect_error(
     add_resource(p, "new", "http://example.com/no_such_file.csv"),
-    class = "frictionless_error_not_found_url"
+    class = "frictionless_error_url_not_found"
   )
 })
 

--- a/tests/testthat/test-check_path.R
+++ b/tests/testthat/test-check_path.R
@@ -1,0 +1,75 @@
+test_that("check_path() returns path prepended with directory", {
+  expect_identical(
+    check_path("deployments_schema.json", directory = "data"),
+    "data/deployments_schema.json"
+  )
+
+  # No prepending with default directory (NULL)
+  expect_identical(
+    check_path("data/deployments_schema.json"),
+    "data/deployments_schema.json"
+  )
+
+  # Directory is ignored for URL
+  url <- file.path("https://github.com/frictionlessdata/frictionless-r/",
+                   "raw/main/tests/testthat/data/deployments_schema.json")
+  expect_identical(check_path(url, directory = "data"), url)
+})
+
+test_that("check_path() returns error on absolute path when safe = TRUE", {
+  expect_error(
+    check_path("/dir/file.txt", safe = TRUE),
+    class = "frictionless_error_unsafe_absolute_path"
+  )
+  expect_error(
+    frictionless:::check_path("/dir/file.txt", safe = TRUE),
+    "`path` must be a safe path.",
+    fixed = TRUE
+  )
+  expect_error(
+    frictionless:::check_path("/dir/file.txt", safe = TRUE),
+    "'/dir/file.txt' is an absolute path starting with \"/\" which is unsafe.",
+    fixed = TRUE
+  )
+})
+
+test_that("check_path() returns error on relative parent path when safe = TRUE", {
+  expect_error(
+    check_path("../dir/file.txt", safe = TRUE),
+    class = "frictionless_error_unsafe_relative_path"
+  )
+  expect_error(
+    check_path("../dir/file.txt", safe = TRUE),
+    "`path` must be a safe path.",
+    fixed = TRUE
+  )
+  expect_error(
+    check_path("../dir/file.txt", safe = TRUE),
+    "'../dir/file.txt' is a relative parent path starting with \"../\" which is unsafe.",
+    fixed = TRUE
+  )
+})
+
+test_that("check_path() returns error when local file cannot be found", {
+  expect_error(
+    check_path("no_such_file.csv"),
+    class = "frictionless_error_not_found_path"
+  )
+  expect_error(
+    check_path("no_such_file.csv"),
+    "Can't find file at 'no_such_file.csv'.",
+    fixed = TRUE
+  )
+})
+
+test_that("check_path() returns error when remote file cannot be found", {
+  expect_error(
+    check_path("http://example.com/no_such_file.csv"),
+    class = "frictionless_error_not_found_url"
+  )
+  expect_error(
+    check_path("http://example.com/no_such_file.csv"),
+    "Can't find file at <http://example.com/no_such_file.csv>.",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-check_path.R
+++ b/tests/testthat/test-check_path.R
@@ -19,16 +19,16 @@ test_that("check_path() returns path prepended with directory", {
 test_that("check_path() returns error on absolute path when safe = TRUE", {
   expect_error(
     check_path("/dir/file.txt", safe = TRUE),
-    class = "frictionless_error_unsafe_absolute_path"
+    class = "frictionless_error_path_unsafe_absolute"
   )
   expect_error(
     frictionless:::check_path("/dir/file.txt", safe = TRUE),
-    "`path` must be a safe path.",
+    regexp = "`path` must be a safe path.",
     fixed = TRUE
   )
   expect_error(
     frictionless:::check_path("/dir/file.txt", safe = TRUE),
-    "'/dir/file.txt' is an absolute path starting with \"/\" which is unsafe.",
+    regexp = "'/dir/file.txt' is an absolute path starting with \"/\" which is unsafe.",
     fixed = TRUE
   )
 })
@@ -36,16 +36,16 @@ test_that("check_path() returns error on absolute path when safe = TRUE", {
 test_that("check_path() returns error on relative parent path when safe = TRUE", {
   expect_error(
     check_path("../dir/file.txt", safe = TRUE),
-    class = "frictionless_error_unsafe_relative_path"
+    class = "frictionless_error_path_unsafe_relative"
   )
   expect_error(
     check_path("../dir/file.txt", safe = TRUE),
-    "`path` must be a safe path.",
+    regexp = "`path` must be a safe path.",
     fixed = TRUE
   )
   expect_error(
     check_path("../dir/file.txt", safe = TRUE),
-    "'../dir/file.txt' is a relative parent path starting with \"../\" which is unsafe.",
+    regexp = "'../dir/file.txt' is a relative parent path starting with \"../\" which is unsafe.",
     fixed = TRUE
   )
 })
@@ -53,11 +53,11 @@ test_that("check_path() returns error on relative parent path when safe = TRUE",
 test_that("check_path() returns error when local file cannot be found", {
   expect_error(
     check_path("no_such_file.csv"),
-    class = "frictionless_error_not_found_path"
+    class = "frictionless_error_path_not_found"
   )
   expect_error(
     check_path("no_such_file.csv"),
-    "Can't find file at 'no_such_file.csv'.",
+    regexp = "Can't find file at 'no_such_file.csv'.",
     fixed = TRUE
   )
 })
@@ -65,11 +65,11 @@ test_that("check_path() returns error when local file cannot be found", {
 test_that("check_path() returns error when remote file cannot be found", {
   expect_error(
     check_path("http://example.com/no_such_file.csv"),
-    class = "frictionless_error_not_found_url"
+    class = "frictionless_error_url_not_found"
   )
   expect_error(
     check_path("http://example.com/no_such_file.csv"),
-    "Can't find file at <http://example.com/no_such_file.csv>.",
+    regexp = "Can't find file at <http://example.com/no_such_file.csv>.",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -77,8 +77,7 @@ test_that("read_package() returns error on missing file and properties", {
   # No file locally
   expect_error(
     read_package("nofile.json"),
-    "Can't find file at 'nofile.json'",
-    fixed = TRUE
+    class = "frictionless_error_not_found_path"
   )
 
   # Not a json file
@@ -122,8 +121,7 @@ test_that("read_package() returns error on missing file and properties", {
   # No file remotely
   expect_error(
     read_package("http://example.com/nofile.json"),
-    "Can't find file at <http://example.com/nofile.json>.",
-    fixed = TRUE
+    class = "frictionless_error_not_found_url"
   )
 })
 

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -77,7 +77,7 @@ test_that("read_package() returns error on missing file and properties", {
   # No file locally
   expect_error(
     read_package("nofile.json"),
-    class = "frictionless_error_not_found_path"
+    class = "frictionless_error_path_not_found"
   )
 
   # Not a json file
@@ -121,7 +121,7 @@ test_that("read_package() returns error on missing file and properties", {
   # No file remotely
   expect_error(
     read_package("http://example.com/nofile.json"),
-    class = "frictionless_error_not_found_url"
+    class = "frictionless_error_url_not_found"
   )
 })
 

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -77,7 +77,7 @@ test_that("read_package() returns error on missing file and properties", {
   # No file locally
   expect_error(
     read_package("nofile.json"),
-    "Can't find file at `nofile.json`",
+    "Can't find file at 'nofile.json'",
     fixed = TRUE
   )
 
@@ -122,7 +122,7 @@ test_that("read_package() returns error on missing file and properties", {
   # No file remotely
   expect_error(
     read_package("http://example.com/nofile.json"),
-    "Can't find file at `http://example.com/nofile.json`.",
+    "Can't find file at <http://example.com/nofile.json>.",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -135,35 +135,35 @@ test_that("read_resource() returns error on incorrect resource", {
   p_invalid$resources[[1]]$path <- "http://example.com/no_such_file.csv"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    class = "frictionless_error_not_found_url"
+    class = "frictionless_error_url_not_found"
   )
 
   # No file at path
   p_invalid$resources[[1]]$path <- "no_such_file.csv"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    class = "frictionless_error_not_found_path"
+    class = "frictionless_error_path_not_found"
   )
 
   # No file at paths
   p_invalid$resources[[1]]$path <- c("deployments.csv", "no_such_file.csv")
   expect_error(
     read_resource(p_invalid, "deployments"),
-    class = "frictionless_error_not_found_path"
+    class = "frictionless_error_path_not_found"
   )
 
   # Path is absolute path
   p_invalid$resources[[1]]$path <- "/inst/extdata/deployments.csv"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    class = "frictionless_error_unsafe_absolute_path"
+    class = "frictionless_error_path_unsafe_absolute"
   )
 
   # Path is relative parent path
   p_invalid$resources[[1]]$path <- "../../inst/extdata/deployments.csv"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    class = "frictionless_error_unsafe_relative_path"
+    class = "frictionless_error_path_unsafe_relative"
   )
 
   # Add valid path
@@ -194,14 +194,14 @@ test_that("read_resource() returns error on incorrect resource", {
   p_invalid$resources[[1]]$schema <- "http://example.com/no_schema.json"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    class = "frictionless_error_not_found_url"
+    class = "frictionless_error_url_not_found"
   )
 
   # No file at schema
   p_invalid$resources[[1]]$schema <- "no_schema.json"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    class = "frictionless_error_not_found_path"
+    class = "frictionless_error_path_not_found"
   )
 
   # No fields

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -294,14 +294,14 @@ test_that("read_resource() can read safe local and remote Table Schema,
     "/tests/testthat/data/deployments_schema.json"
   expect_error(
     read_resource(p_unsafe, "deployments"),
-    class = "frictionless_error_unsafe_absolute_path"
+    class = "frictionless_error_path_unsafe_absolute"
   )
 
   # Schema is relative parent path
   p_unsafe$resources[[1]]$schema <- "../testthat/data/deployments_schema.json"
   expect_error(
     read_resource(p_unsafe, "deployments"),
-    class = "frictionless_error_unsafe_relative_path"
+    class = "frictionless_error_path_unsafe_relative"
   )
 
   # Schema is local path
@@ -340,14 +340,14 @@ test_that("read_resource() can read safe local and remote CSV dialect", {
   p_unsafe$resources[[1]]$dialect <- "/tests/testthat/data/dialect.json"
   expect_error(
     read_resource(p_unsafe, "deployments"),
-    class = "frictionless_error_unsafe_absolute_path"
+    class = "frictionless_error_path_unsafe_absolute"
   )
 
   # Dialect is relative parent path
   p_unsafe$resources[[1]]$dialect <- "../testthat/data/dialect.json"
   expect_error(
     read_resource(p_unsafe, "deployments"),
-    class = "frictionless_error_unsafe_relative_path"
+    class = "frictionless_error_path_unsafe_relative"
   )
 
   # Dialect is local path

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -135,7 +135,7 @@ test_that("read_resource() returns error on incorrect resource", {
   p_invalid$resources[[1]]$path <- "http://example.com/no_such_file.csv"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    "Can't find file at `http://example.com/no_such_file.csv`.",
+    "Can't find file at <http://example.com/no_such_file.csv>.",
     fixed = TRUE
   )
 
@@ -143,7 +143,7 @@ test_that("read_resource() returns error on incorrect resource", {
   p_invalid$resources[[1]]$path <- "no_such_file.csv"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    "Can't find file at `./no_such_file.csv`.",
+    "Can't find file at './no_such_file.csv'.",
     fixed = TRUE
   )
 
@@ -151,7 +151,7 @@ test_that("read_resource() returns error on incorrect resource", {
   p_invalid$resources[[1]]$path <- c("deployments.csv", "no_such_file.csv")
   expect_error(
     read_resource(p_invalid, "deployments"),
-    "Can't find file at `./deployments.csv`.",
+    "Can't find file at './deployments.csv'.",
     fixed = TRUE
   )
 
@@ -160,8 +160,8 @@ test_that("read_resource() returns error on incorrect resource", {
   expect_error(
     read_resource(p_invalid, "deployments"),
     paste(
-      "`/inst/extdata/deployments.csv` is an absolute path (`/`)",
-      "which is unsafe."
+      "'/inst/extdata/deployments.csv' is an absolute path",
+      "starting with \"/\" which is unsafe."
     ),
     fixed = TRUE
   )
@@ -171,8 +171,8 @@ test_that("read_resource() returns error on incorrect resource", {
   expect_error(
     read_resource(p_invalid, "deployments"),
     paste(
-      "`../../inst/extdata/deployments.csv` is a relative parent path (`../`)",
-      "which is unsafe."
+      "'../../inst/extdata/deployments.csv' is a relative parent path",
+      "starting with \"../\" which is unsafe."
     ),
     fixed = TRUE
   )
@@ -205,7 +205,7 @@ test_that("read_resource() returns error on incorrect resource", {
   p_invalid$resources[[1]]$schema <- "http://example.com/no_schema.json"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    "Can't find file at `http://example.com/no_schema.json`.",
+    "Can't find file at <http://example.com/no_schema.json>.",
     fixed = TRUE
   )
 
@@ -213,8 +213,8 @@ test_that("read_resource() returns error on incorrect resource", {
   p_invalid$resources[[1]]$schema <- "no_schema.json"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    "Can't find file at `.*no_schema.json`",
-    # no fixed = TRUE, since full returned path depends on system
+    "Can't find file at '.*/no_schema.json'.",
+    fixed = FALSE # Full returned path depends on system
   )
 
   # No fields
@@ -308,8 +308,8 @@ test_that("read_resource() can read safe local and remote Table Schema,
   expect_error(
     read_resource(p_unsafe, "deployments"),
     paste(
-      "`/tests/testthat/data/deployments_schema.json` is an absolute path",
-      "(`/`) which is unsafe."
+      "'/tests/testthat/data/deployments_schema.json' is an absolute path",
+      "starting with \"/\" which is unsafe."
     ),
     fixed = TRUE
   )
@@ -319,8 +319,8 @@ test_that("read_resource() can read safe local and remote Table Schema,
   expect_error(
     read_resource(p_unsafe, "deployments"),
     paste(
-      "`../testthat/data/deployments_schema.json` is a relative parent path",
-      "(`../`) which is unsafe."
+      "'../testthat/data/deployments_schema.json' is a relative parent path",
+      "starting with \"../\" which is unsafe."
     ),
     fixed = TRUE
   )
@@ -362,8 +362,8 @@ test_that("read_resource() can read safe local and remote CSV dialect", {
   expect_error(
     read_resource(p_unsafe, "deployments"),
     paste(
-      "`/tests/testthat/data/dialect.json` is an absolute path",
-      "(`/`) which is unsafe."
+      "'/tests/testthat/data/dialect.json' is an absolute path",
+      "starting with \"/\" which is unsafe."
     ),
     fixed = TRUE
   )
@@ -373,8 +373,8 @@ test_that("read_resource() can read safe local and remote CSV dialect", {
   expect_error(
     read_resource(p_unsafe, "deployments"),
     paste(
-      "`../testthat/data/dialect.json` is a relative parent path",
-      "(`../`) which is unsafe."
+      "'../testthat/data/dialect.json' is a relative parent path",
+      "starting with \"../\" which is unsafe."
     ),
     fixed = TRUE
   )

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -135,46 +135,35 @@ test_that("read_resource() returns error on incorrect resource", {
   p_invalid$resources[[1]]$path <- "http://example.com/no_such_file.csv"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    "Can't find file at <http://example.com/no_such_file.csv>.",
-    fixed = TRUE
+    class = "frictionless_error_not_found_url"
   )
 
   # No file at path
   p_invalid$resources[[1]]$path <- "no_such_file.csv"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    "Can't find file at './no_such_file.csv'.",
-    fixed = TRUE
+    class = "frictionless_error_not_found_path"
   )
 
   # No file at paths
   p_invalid$resources[[1]]$path <- c("deployments.csv", "no_such_file.csv")
   expect_error(
     read_resource(p_invalid, "deployments"),
-    "Can't find file at './deployments.csv'.",
-    fixed = TRUE
+    class = "frictionless_error_not_found_path"
   )
 
   # Path is absolute path
   p_invalid$resources[[1]]$path <- "/inst/extdata/deployments.csv"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    paste(
-      "'/inst/extdata/deployments.csv' is an absolute path",
-      "starting with \"/\" which is unsafe."
-    ),
-    fixed = TRUE
+    class = "frictionless_error_unsafe_absolute_path"
   )
 
   # Path is relative parent path
   p_invalid$resources[[1]]$path <- "../../inst/extdata/deployments.csv"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    paste(
-      "'../../inst/extdata/deployments.csv' is a relative parent path",
-      "starting with \"../\" which is unsafe."
-    ),
-    fixed = TRUE
+    class = "frictionless_error_unsafe_relative_path"
   )
 
   # Add valid path
@@ -205,16 +194,14 @@ test_that("read_resource() returns error on incorrect resource", {
   p_invalid$resources[[1]]$schema <- "http://example.com/no_schema.json"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    "Can't find file at <http://example.com/no_schema.json>.",
-    fixed = TRUE
+    class = "frictionless_error_not_found_url"
   )
 
   # No file at schema
   p_invalid$resources[[1]]$schema <- "no_schema.json"
   expect_error(
     read_resource(p_invalid, "deployments"),
-    "Can't find file at '.*/no_schema.json'.",
-    fixed = FALSE # Full returned path depends on system
+    class = "frictionless_error_not_found_path"
   )
 
   # No fields
@@ -307,22 +294,14 @@ test_that("read_resource() can read safe local and remote Table Schema,
     "/tests/testthat/data/deployments_schema.json"
   expect_error(
     read_resource(p_unsafe, "deployments"),
-    paste(
-      "'/tests/testthat/data/deployments_schema.json' is an absolute path",
-      "starting with \"/\" which is unsafe."
-    ),
-    fixed = TRUE
+    class = "frictionless_error_unsafe_absolute_path"
   )
 
   # Schema is relative parent path
   p_unsafe$resources[[1]]$schema <- "../testthat/data/deployments_schema.json"
   expect_error(
     read_resource(p_unsafe, "deployments"),
-    paste(
-      "'../testthat/data/deployments_schema.json' is a relative parent path",
-      "starting with \"../\" which is unsafe."
-    ),
-    fixed = TRUE
+    class = "frictionless_error_unsafe_relative_path"
   )
 
   # Schema is local path
@@ -361,22 +340,14 @@ test_that("read_resource() can read safe local and remote CSV dialect", {
   p_unsafe$resources[[1]]$dialect <- "/tests/testthat/data/dialect.json"
   expect_error(
     read_resource(p_unsafe, "deployments"),
-    paste(
-      "'/tests/testthat/data/dialect.json' is an absolute path",
-      "starting with \"/\" which is unsafe."
-    ),
-    fixed = TRUE
+    class = "frictionless_error_unsafe_absolute_path"
   )
 
   # Dialect is relative parent path
   p_unsafe$resources[[1]]$dialect <- "../testthat/data/dialect.json"
   expect_error(
     read_resource(p_unsafe, "deployments"),
-    paste(
-      "'../testthat/data/dialect.json' is a relative parent path",
-      "starting with \"../\" which is unsafe."
-    ),
-    fixed = TRUE
+    class = "frictionless_error_unsafe_relative_path"
   )
 
   # Dialect is local path

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -68,18 +68,15 @@ test_that("write_package() does not overwrite existing data files", {
   # Create files in directory
   files <- c(
     datapackage = file.path(dir, "datapackage.json"),
-    deployments = file.path(dir, "deployments.csv"),
-    observations_1 = file.path(dir, "observations_1.csv"),
-    observations_2 = file.path(dir, "observations_2.csv")
+    deployments = file.path(dir, "deployments.csv") # Local path
+    # observations_1, observations_2 have remote path and would not be written
   )
   file.create(files) # Size for these files will be 0
 
   # Write package to directory, expect only datapackage.json is overwritten
   suppressMessages(write_package(p, dir))
   expect_gt(file.info(files["datapackage"])$size, 0) # Overwitten
-  expect_identical(file.info(files["deployments"])$size, 0)
-  expect_identical(file.info(files["observations_1"])$size, 0)
-  expect_identical(file.info(files["observations_2"])$size, 0)
+  expect_identical(file.info(files["deployments"])$size, 0) # Remains the same
 })
 
 test_that("write_package() copies file(s) for path = local in local package", {


### PR DESCRIPTION
- Moves `check_path()` to own file
- Use cli for error messages (with clickable links)
- Drops use of `assert_that()`
- Use error classes. This allows for [easier testing](https://testthat.r-lib.org/reference/expect_error.html#testing-message-vs-class), where there is no need to update 10 tests if the error message is changed. See 307f1d7b26c9347729d5795258f572fdaa4fe565

I'm curious to see how the coverage will go up or down. Might be useful to include a `test-check_path()` to test (once!) for the error messages themselves (to capture spelling regressions).