### PR TITLE
Update GH actions to use R 3.x

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: '3.6.3'}
+          - {os: windows-latest,   r: '3.6.3'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,6 +23,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: '3.5'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: '3.5'}
+          - {os: ubuntu-latest,   r: '3.6'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: '3.6'}
+          - {os: ubuntu-latest,   r: '3.6.3'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ URL: https://github.com/frictionlessdata/frictionless-r,
     https://docs.ropensci.org/frictionless/
 BugReports: https://github.com/frictionlessdata/frictionless-r/issues
 Depends:
-    R (>= 3.5.0)
+    R (>= 3.6.0)
 Imports:
     cli,
     dplyr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Suggests:
     lubridate,
     rmarkdown,
     stringi,
-    testthat (>= 3.0.0),
+    testthat,
     tibble
 VignetteBuilder: 
     knitr


### PR DESCRIPTION
This PR adds an automated configuration OS/R version for R-CMD-CHECK action. In particular, we would like to check that users using the minimal R supported version (3.5) can install the package and use it without any error.