### PR TITLE
Return error for resources with path and data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # frictionless (development version)
 
+* `read_resource()` now returns error if both `path` and `data` are provided (#143).
 * [checklist](https://github.com/inbo/checklist) tooling was removed, in favour of `CITATION.cff` for citation and Zenodo deposit.
 
 # frictionless 1.1.0

--- a/R/get_resource.R
+++ b/R/get_resource.R
@@ -45,6 +45,16 @@ get_resource <- function(package, resource_name) {
     )
   }
 
+  # Check if that either data or path is set, not both.
+  if (all(c("data", "path") %in% names(resource))) {
+    cli::cli_abort(
+      "Resource {.val {resource_name}} is invalid:
+        It has both properties {.field path} and {.field data} while they
+        are mutually exclusive",
+      class = "frictionless_error_resource_both_path_and_data"
+    )
+  }
+
   # Assign read_from property (based on path, then df, then data)
   if (length(resource$path) != 0) {
     if (all(is_url(resource$path))) {

--- a/R/get_resource.R
+++ b/R/get_resource.R
@@ -45,13 +45,12 @@ get_resource <- function(package, resource_name) {
     )
   }
 
-  # Check if that either data or path is set, not both.
+  # Check that either data or path is set, not both
   if (all(c("data", "path") %in% names(resource))) {
     cli::cli_abort(
-      "Resource {.val {resource_name}} is invalid:
-        It has both properties {.field path} and {.field data} while they
-        are mutually exclusive",
-      class = "frictionless_error_resource_both_path_and_data"
+      "Resource {.val {resource_name}} must have a {.field path} or
+       {.field data} property, not both.",
+      class = "frictionless_error_resource_both_path_data"
     )
   }
 

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -9,6 +9,24 @@ test_that("read_resource() returns a tibble", {
   expect_s3_class(read_resource(p, "new"), "tbl")         # via df
 })
 
+test_that("read_resource() doesn't allow both path and data in one resource", {
+  skip_if_offline()
+  p_invalid <- example_package
+  # Assign the data from media to observations, so it has both path and data
+  p_invalid$resources[[2]]$data <- p_invalid$resources[[3]]$data
+
+  # Test for correct error class
+  expect_error(
+    read_resource(p_invalid, "observations"),
+    class = "frictionless_error_resource_both_path_and_data"
+  )
+  # Test for substring of error message
+  expect_error(
+    read_resource(p_invalid, "observations"),
+    regexp = 'mutually exclusive'
+  )
+})
+
 test_that("read_resource() allows column selection", {
   skip_if_offline()
   p <- example_package

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -13,8 +13,8 @@ test_that("read_resource() doesn't allow both path and data in one resource", {
   skip_if_offline()
   p_invalid <- example_package
   # Assign the data from media to observations, so it has both path and data
-  p_invalid$resources[[2]]$data <- p_invalid$resources[[3]]$data
-
+  purrr::pluck(p_invalid, "resources", 2, "data") <-
+    purrr::pluck(p_invalid, "resources", 3, "data")
   # Test for correct error class
   expect_error(
     read_resource(p_invalid, "observations"),


### PR DESCRIPTION
Fix #143.

get_resource() now returns an error if a resource has both a path and data value (not NULL). 