### PR TITLE
Replace magrittr pipes with base pipes

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -11,7 +11,6 @@ knitr::opts_chunk$set(
   fig.path = "man/figures/README-",
   out.width = "100%"
 )
-library(dplyr) # For %>%
 ```
 
 # frictionless
@@ -79,13 +78,13 @@ You can also create your own Data Package, add data and **write** it to disk:
 ```{r write_example}
 # Create a Data Package and add the "iris" data frame as a resource
 my_package <-
-  create_package() %>%
+  create_package() |>
   add_resource(resource_name = "iris", data = iris)
 
 my_package
 
 # Write the Data Package to disk
-my_package %>%
+my_package |>
   write_package("my_directory")
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,16 @@ package
 #> • acceleration
 #> For more information, see <https://doi.org/10.5281/zenodo.10053702>.
 #> Use `unclass()` to print the Data Package as a list.
+```
+
+``` r
 
 # List resources
 resources(package)
 #> [1] "reference-data" "gps"            "acceleration"
+```
+
+``` r
 
 # Read data from the resource "gps"
 # This will return a single data frame, even though the data are split over 
@@ -112,16 +118,19 @@ disk:
 ``` r
 # Create a Data Package and add the "iris" data frame as a resource
 my_package <-
-  create_package() %>%
+  create_package() |>
   add_resource(resource_name = "iris", data = iris)
 
 my_package
 #> A Data Package with 1 resource:
 #> • iris
 #> Use `unclass()` to print the Data Package as a list.
+```
+
+``` r
 
 # Write the Data Package to disk
-my_package %>%
+my_package |>
   write_package("my_directory")
 ```
 

--- a/vignettes/frictionless.Rmd
+++ b/vignettes/frictionless.Rmd
@@ -167,11 +167,8 @@ Create a Data Package with `create_package()` and add your data frame as a resou
 
 
 ```r
-# Load dplyr or magrittr to support %>% pipes
-library(dplyr, warn.conflicts = FALSE) # or library(magrittr)
-
 my_package <-
-  create_package() %>%
+  create_package() |>
   add_resource(resource_name = "iris", data = iris)
 ```
 
@@ -192,7 +189,7 @@ By default, `add_resource()` will create a **Table Schema** for your data frame,
 
 ```r
 iris_schema <-
-  my_package %>%
+  my_package |>
   get_schema("iris")
 
 str(iris_schema)
@@ -310,8 +307,8 @@ Let's add `iris` as a resource to your Data Package again, but this time with th
 
 ```r
 my_package <-
-  my_package %>%
-  remove_resource("iris") %>% # Remove originally added resource
+  my_package |>
+  remove_resource("iris") |> # Remove originally added resource
   add_resource(
     resource_name = "iris",
     data = iris,
@@ -331,7 +328,7 @@ path_2 <- system.file("extdata", "observations_2.csv", package = "frictionless")
 
 # Add both CSV files as a single resource
 my_package <-
-  my_package %>%
+  my_package |>
   add_resource(resource_name = "observations", data = c(path_1, path_2))
 ```
 

--- a/vignettes/frictionless.Rmd.orig
+++ b/vignettes/frictionless.Rmd.orig
@@ -90,11 +90,8 @@ dplyr::as_tibble(iris)
 Create a Data Package with `create_package()` and add your data frame as a resource with the name `iris`:
 
 ```{r}
-# Load dplyr or magrittr to support %>% pipes
-library(dplyr, warn.conflicts = FALSE) # or library(magrittr)
-
 my_package <-
-  create_package() %>%
+  create_package() |>
   add_resource(resource_name = "iris", data = iris)
 ```
 
@@ -110,7 +107,7 @@ By default, `add_resource()` will create a **Table Schema** for your data frame,
 
 ```{r}
 iris_schema <-
-  my_package %>%
+  my_package |>
   get_schema("iris")
 
 str(iris_schema)
@@ -158,8 +155,8 @@ Let's add `iris` as a resource to your Data Package again, but this time with th
 
 ```{r}
 my_package <-
-  my_package %>%
-  remove_resource("iris") %>% # Remove originally added resource
+  my_package |>
+  remove_resource("iris") |> # Remove originally added resource
   add_resource(
     resource_name = "iris",
     data = iris,
@@ -178,7 +175,7 @@ path_2 <- system.file("extdata", "observations_2.csv", package = "frictionless")
 
 # Add both CSV files as a single resource
 my_package <-
-  my_package %>%
+  my_package |>
   add_resource(resource_name = "observations", data = c(path_1, path_2))
 ```
 


### PR DESCRIPTION
After #240, we can use base pipes in our vignettes and examples

What is `frictionless.Rmd.orig` used for? 