### PR TITLE
Use a deviating dialect for one of the resources in `example_package`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 * `read_resource()` now returns error if both `path` and `data` are provided (#143).
 * `write_package()` no longer writes to `"."` by default, since this is not allowed by CRAN policies. The user needs to explicitly define a directory (#205).
 * `write_package()` now writes incoming `null` values back to `NULL` in `datapackage.json`, rather than empty an empty lists. Properties that are assigned `NA` and `NULL` by the user, remain being written as `null` and removed respectively (#203).
-* The included dataset `example_package` is removed in favour of the function `example_package()`. This function allows to reproducibly provide a _local Data Package_, while before it needed to be a remote package. The `observations` resource was also changed from a remote to a local resource, allowing the entire example Data Package to be read locally. Examples and tests were updated (#114).
+* The included dataset `example_package` is removed in favour of the function `example_package()`. This function allows to reproducibly provide a _local Data Package_, while before it needed to be a remote package. The `observations` resource was also changed from a remote to a local resource - allowing the entire example Data Package to be read locally - and from CSV to TSV - allowing to test for dialect. Examples and tests were updated (#114, #253).
 
 ## Changes for developers
 

--- a/R/add_resource.R
+++ b/R/add_resource.R
@@ -68,14 +68,15 @@
 #'   title = "Positions with schema"
 #' )
 #'
-#' # Replace the resource "observations" with a file-based resource (2 CSV files)
-#' path_1 <- system.file("extdata", "observations_1.csv", package = "frictionless")
-#' path_2 <- system.file("extdata", "observations_2.csv", package = "frictionless")
+#' # Replace the resource "observations" with a file-based resource (2 TSV files)
+#' path_1 <- system.file("extdata", "observations_1.tsv", package = "frictionless")
+#' path_2 <- system.file("extdata", "observations_2.tsv", package = "frictionless")
 #' package <- add_resource(
 #'   package,
 #'   resource_name = "observations",
 #'   data = c(path_1, path_2),
-#'   replace = TRUE
+#'   replace = TRUE,
+#'   delim = "\t"
 #' )
 #'
 #' # List the resources ("positions" and "positions_with_schema" added)

--- a/R/example_package.R
+++ b/R/example_package.R
@@ -6,7 +6,7 @@
 #' 1. `deployments`: one local data file referenced in
 #'    `"path": "deployments.csv"`.
 #' 2. `observations`: two local data files referenced in
-#'    `"path": ["observations_1.csv", "observations_2.csv"]`.
+#'    `"path": ["observations_1.tsv", "observations_2.tsv"]`.
 #' 3. `media`: inline data stored in `data`.
 #'
 #' @return A Data Package object, see [create_package()].

--- a/inst/extdata/datapackage.json
+++ b/inst/extdata/datapackage.json
@@ -70,13 +70,15 @@
     },
     {
       "name": "observations",
-      "path": ["observations_1.csv", "observations_2.csv"],
+      "path": ["observations_1.tsv", "observations_2.tsv"],
       "profile": "tabular-data-resource",
       "title": "Camera trap observations",
       "format": "csv",
       "mediatype": "text/csv",
       "encoding": "utf-8",
-      "dialect": {"delimiter": "\t"},
+      "dialect": {
+        "delimiter": "\t"
+      },
       "schema": {
         "fields": [
           {

--- a/inst/extdata/datapackage.json
+++ b/inst/extdata/datapackage.json
@@ -76,6 +76,7 @@
       "format": "csv",
       "mediatype": "text/csv",
       "encoding": "utf-8",
+      "dialect": {"delimiter": "\t"},
       "schema": {
         "fields": [
           {

--- a/inst/extdata/observations_1.csv
+++ b/inst/extdata/observations_1.csv
@@ -1,4 +1,0 @@
-observation_id,deployment_id,timestamp,scientific_name,count,life_stage,comments
-1-1,1,2020-09-28T02:13:07+02:00,Capreolus capreolus,1,juvenile,Comment 1
-1-2,1,2020-09-28T16:59:17+01:00,Capreolus capreolus,1,adult,Comment 2
-1-3,1,2020-09-28T17:35:23+01:00,Lepus europaeus,1,adult,Comment 3

--- a/inst/extdata/observations_1.tsv
+++ b/inst/extdata/observations_1.tsv
@@ -1,0 +1,4 @@
+observation_id	deployment_id	timestamp	scientific_name	count	life_stage	comments
+1-1	1	2020-09-28T00:13:07Z	Capreolus capreolus	1	juvenile	Comment 1
+1-2	1	2020-09-28T15:59:17Z	Capreolus capreolus	1	adult	Comment 2
+1-3	1	2020-09-28T16:35:23Z	Lepus europaeus	1	adult	Comment 3

--- a/inst/extdata/observations_2.csv
+++ b/inst/extdata/observations_2.csv
@@ -1,6 +1,0 @@
-observation_id,deployment_id,timestamp,scientific_name,count,life_stage,comments
-1-4,1,2020-09-28T18:04:04+01:00,Lepus europaeus,1,adult,
-1-5,1,2020-09-28T20:19:54+01:00,Sus scrofa,2,unknown,
-2-1,2,2021-10-01T02:25:06+01:00,Sus scrofa,1,unknown,Duplicate
-2-2,2,2021-10-01T02:25:06+01:00,Sus scrofa,1,unknown,Duplicate
-2-3,2,2021-10-01T05:47:30+01:00,Sus scrofa,1,unknown,

--- a/inst/extdata/observations_2.tsv
+++ b/inst/extdata/observations_2.tsv
@@ -1,0 +1,6 @@
+observation_id	deployment_id	timestamp	scientific_name	count	life_stage	comments
+1-4	1	2020-09-28T17:04:04Z	Lepus europaeus	1	adult	NA
+1-5	1	2020-09-28T19:19:54Z	Sus scrofa	2	unknown	NA
+2-1	2	2021-10-01T01:25:06Z	Sus scrofa	1	unknown	Duplicate
+2-2	2	2021-10-01T01:25:06Z	Sus scrofa	1	unknown	Duplicate
+2-3	2	2021-10-01T04:47:30Z	Sus scrofa	1	unknown	NA

--- a/man/add_resource.Rd
+++ b/man/add_resource.Rd
@@ -92,14 +92,15 @@ package <- add_resource(
   title = "Positions with schema"
 )
 
-# Replace the resource "observations" with a file-based resource (2 CSV files)
-path_1 <- system.file("extdata", "observations_1.csv", package = "frictionless")
-path_2 <- system.file("extdata", "observations_2.csv", package = "frictionless")
+# Replace the resource "observations" with a file-based resource (2 TSV files)
+path_1 <- system.file("extdata", "observations_1.tsv", package = "frictionless")
+path_2 <- system.file("extdata", "observations_2.tsv", package = "frictionless")
 package <- add_resource(
   package,
   resource_name = "observations",
   data = c(path_1, path_2),
-  replace = TRUE
+  replace = TRUE,
+  delim = "\t"
 )
 
 # List the resources ("positions" and "positions_with_schema" added)

--- a/man/example_package.Rd
+++ b/man/example_package.Rd
@@ -17,7 +17,7 @@ camera trap data organized in 3 Data Resources:
 \item \code{deployments}: one local data file referenced in
 \code{"path": "deployments.csv"}.
 \item \code{observations}: two local data files referenced in
-\verb{"path": ["observations_1.csv", "observations_2.csv"]}.
+\verb{"path": ["observations_1.tsv", "observations_2.tsv"]}.
 \item \code{media}: inline data stored in \code{data}.
 }
 }

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -100,6 +100,7 @@ test_that("write_package() copies file(s) for path = local in local package", {
   on.exit(unlink(dir, recursive = TRUE))
   p_written <- suppressMessages(write_package(p, dir))
 
+  # Original resource "deployments" with local path
   expect_identical(p_written$resources[[1]]$path, "deployments.csv")
   expect_true(file.exists(file.path(dir, "deployments.csv")))
 

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -75,8 +75,8 @@ test_that("write_package() does not overwrite existing data files", {
   files <- c(
     datapackage = file.path(dir, "datapackage.json"),
     # deployments: has remote path, should not be written
-    observations_1 = file.path(dir, "observations_1.csv"),
-    observations_2 = file.path(dir, "observations_2.csv")
+    observations_1 = file.path(dir, "observations_1.tsv"),
+    observations_2 = file.path(dir, "observations_2.tsv")
   )
   file.create(files) # Size for these files will be 0
 
@@ -93,24 +93,23 @@ test_that("write_package() copies file(s) for path = local in local package", {
   # Change one local path to URL
   p$resources[[2]]$path[[1]] <- file.path(
     "https://raw.githubusercontent.com/frictionlessdata/frictionless-r",
-    "main/inst/extdata/observations_1.csv"
+    "main/inst/extdata/observations_1.tsv"
   )
   p <- add_resource(p, "new", test_path("data/df.csv"))
   dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))
   p_written <- suppressMessages(write_package(p, dir))
 
-  # Original resource "deployments" with local path
   expect_identical(p_written$resources[[1]]$path, "deployments.csv")
   expect_true(file.exists(file.path(dir, "deployments.csv")))
 
   # Original resource "observations" with URL + local path => both local
   expect_identical(
     p_written$resources[[2]]$path,
-    c("observations_1.csv", "observations_2.csv")
+    c("observations_1.tsv", "observations_2.tsv")
   )
-  expect_true(file.exists(file.path(dir, "observations_1.csv")))
-  expect_true(file.exists(file.path(dir, "observations_2.csv")))
+  expect_true(file.exists(file.path(dir, "observations_1.tsv")))
+  expect_true(file.exists(file.path(dir, "observations_2.tsv")))
 
   # New resource "new" with local path
   expect_identical(p_written$resources[[4]]$path, "df.csv") # Keeps file name
@@ -131,7 +130,7 @@ test_that("write_package() downloads file(s) for path = local in remote
   # Change one local path to URL
   p$resources[[2]]$path[[1]] <- file.path(
     "https://raw.githubusercontent.com/frictionlessdata/frictionless-r",
-    "main/inst/extdata/observations_1.csv"
+    "main/inst/extdata/observations_1.tsv"
   )
   p <- add_resource(p, "new", test_path("data/df.csv"))
   dir <- file.path(tempdir(), "package")
@@ -145,10 +144,10 @@ test_that("write_package() downloads file(s) for path = local in remote
   # Original resource "observations" with URL + local path => both local
   expect_identical(
     p_written$resources[[2]]$path,
-    c("observations_1.csv", "observations_2.csv")
+    c("observations_1.tsv", "observations_2.tsv")
   )
-  expect_true(file.exists(file.path(dir, "observations_1.csv")))
-  expect_true(file.exists(file.path(dir, "observations_2.csv")))
+  expect_true(file.exists(file.path(dir, "observations_1.tsv")))
+  expect_true(file.exists(file.path(dir, "observations_2.tsv")))
 
   # New resource "new" with local path
   expect_identical(p_written$resources[[4]]$path, "df.csv") # Keeps file name
@@ -292,7 +291,7 @@ test_that("write_package() shows message when downloading file", {
   # Change one local path to URL
   p$resources[[2]]$path[[1]] <- file.path(
     "https://raw.githubusercontent.com/frictionlessdata/frictionless-r",
-    "main/inst/extdata/observations_1.csv"
+    "main/inst/extdata/observations_1.tsv"
   )
   dir <- file.path(tempdir(), "package")
   dir_1 <- file.path(dir, "1")
@@ -306,7 +305,7 @@ test_that("write_package() shows message when downloading file", {
     write_package(p, dir_2),
     regexp = paste0(
       "Downloading file from 'https://raw.githubusercontent.com/",
-      "frictionlessdata/frictionless-r/main/inst/extdata/observations_1.csv'"
+      "frictionlessdata/frictionless-r/main/inst/extdata/observations_1.tsv'"
     ),
     fixed = TRUE
   )

--- a/vignettes/frictionless.Rmd
+++ b/vignettes/frictionless.Rmd
@@ -21,21 +21,21 @@ A [Data Package](https://specs.frictionlessdata.io/data-package/) is a simple co
 Load the frictionless pkg with:
 
 
-```r
+``` r
 library(frictionless)
 ```
 
 To read a Data Package, you need to know the path or URL to its descriptor file, named `datapackage.json`. That file describes the Data Package, provides access points to its Data Resources and can contain dataset-level metadata. Let's read a Data Package descriptor file published on [Zenodo](https://doi.org/10.5281/zenodo.10053702):
 
 
-```r
+``` r
 package <- read_package("https://zenodo.org/records/10053702/files/datapackage.json")
 ```
 
 `read_package()` returns the content of `datapackage.json` as a list with class `datapackage`. When printing a Data Package, you get a summary of its contents:
 
 
-```r
+``` r
 package
 #> A Data Package with 3 resources:
 #> • reference-data
@@ -48,7 +48,7 @@ package
 Since a Data Package is a list, you can pass it to functions that work on lists, such as `str()`:
 
 
-```r
+``` r
 str(package, list.len = 3)
 #> List of 4
 #>  $ id       : chr "https://doi.org/10.5281/zenodo.10053702"
@@ -76,7 +76,7 @@ str(package, list.len = 3)
 The most important aspect of a Data Package are its **Data Resources**, which describe and point to the data. You can list all included resources with `resources()`:
 
 
-```r
+``` r
 resources(package)
 #> [1] "reference-data" "gps"            "acceleration"
 ```
@@ -84,8 +84,15 @@ resources(package)
 This Data Package has 3 resources. Let's read the data from the `gps` resource into a data frame:
 
 
-```r
+``` r
 gps <- read_resource(package, "gps")
+#> Error in `purrr::map_chr()` at frictionless-r/R/get_resource.R:60:7:
+#> ℹ In index: 1.
+#> Caused by error in `check_path()`:
+#> ! Can't find file at <https://zenodo.org/records/10053702/files/O_WESTERSCHELDE-gps-2018.csv.gz>.
+```
+
+``` r
 gps
 #> # A tibble: 73,047 × 21
 #>     `event-id` visible timestamp           `location-long` `location-lat`
@@ -114,7 +121,7 @@ The data frame contains all GPS records, even though the actual data were split 
 You can also read data from a local (e.g. downloaded) Data Package. In fact, there is one included in the frictionless pkg, let's read that one from disk:
 
 
-```r
+``` r
 local_package <- read_package(
   system.file("extdata", "datapackage.json", package = "frictionless")
 )
@@ -125,6 +132,9 @@ local_package
 #> • observations
 #> • media
 #> Use `unclass()` to print the Data Package as a list.
+```
+
+``` r
 
 read_resource(local_package, "media")
 #> # A tibble: 3 × 5
@@ -144,7 +154,7 @@ Data Package is a good format to technically describe your data, e.g. if you are
 The frictionless pkg assumes your data are stored as a data frame or CSV files. Let's use the built-in dataset `iris` as your data frame:
 
 
-```r
+``` r
 # Show content of the data frame "iris"
 dplyr::as_tibble(iris)
 #> # A tibble: 150 × 5
@@ -166,7 +176,7 @@ dplyr::as_tibble(iris)
 Create a Data Package with `create_package()` and add your data frame as a resource with the name `iris`:
 
 
-```r
+``` r
 # Load dplyr or magrittr to support %>% pipes
 library(dplyr, warn.conflicts = FALSE) # or library(magrittr)
 
@@ -180,7 +190,7 @@ Note that you can chain most frictionless functions together using pipes (`%>%` 
 `my_package` now contains one resource:
 
 
-```r
+``` r
 my_package
 #> A Data Package with 1 resource:
 #> • iris
@@ -190,7 +200,7 @@ my_package
 By default, `add_resource()` will create a **Table Schema** for your data frame, describing its field names, field types and (for factors) constraints. You can retrieve the schema of a resource with `get_schema()`. It is a list, which we print here using `str()`:
 
 
-```r
+``` r
 iris_schema <-
   my_package %>%
   get_schema("iris")
@@ -220,7 +230,7 @@ str(iris_schema)
 You can also create a schema from a data frame, using `create_schema()`:
 
 
-```r
+``` r
 iris_schema <- create_schema(iris)
 
 str(iris_schema)
@@ -248,7 +258,7 @@ str(iris_schema)
 Doing so allows you to customize the schema before adding the resource. E.g. let's add a description for `Sepal.Length`:
 
 
-```r
+``` r
 iris_schema$fields[[1]]$description <- "Sepal length in cm."
 # Show result
 str(iris_schema$fields[[1]])
@@ -261,7 +271,7 @@ str(iris_schema$fields[[1]])
 Since schema is a list, you can use the `purrr` pkg to edit multiple elements at once:
 
 
-```r
+``` r
 # Remove description for first field
 iris_schema$fields[[1]]$description <- NULL
 
@@ -308,7 +318,7 @@ str(iris_schema)
 Let's add `iris` as a resource to your Data Package again, but this time with the customized schema. Let's also add `title` and `description` as a metadata properties. Note that you have to remove the originally added resource `iris` with `remove_resource()` first, since Data Packages can only contain uniquely named resources:
 
 
-```r
+``` r
 my_package <-
   my_package %>%
   remove_resource("iris") %>% # Remove originally added resource
@@ -321,24 +331,24 @@ my_package <-
   )
 ```
 
-If you already have your data stored as CSV files and you want to include them _as is_ as a Data Resource, you can do so as well. As with data frames, you can opt to create a Table Schema automatically or provide your own.
+If you already have your data stored as CSV or TSV files and you want to include them _as is_ as a Data Resource, you can do so as well. As with data frames, you can opt to create a Table Schema automatically or provide your own.
 
 
-```r
-# Two CSV files with the same structure
-path_1 <- system.file("extdata", "observations_1.csv", package = "frictionless")
-path_2 <- system.file("extdata", "observations_2.csv", package = "frictionless")
+``` r
+# Two TSV files with the same structure
+path_1 <- system.file("extdata", "observations_1.tsv", package = "frictionless")
+path_2 <- system.file("extdata", "observations_2.tsv", package = "frictionless")
 
-# Add both CSV files as a single resource
+# Add both TSV files as a single resource
 my_package <-
   my_package %>%
-  add_resource(resource_name = "observations", data = c(path_1, path_2))
+  add_resource(resource_name = "observations", data = c(path_1, path_2), delim = "\t")
 ```
 
 Your Data Package now contains 2 resources, but you can add metadata properties as well (see the [Data Package documentation](https://specs.frictionlessdata.io/data-package/#metadata) for an overview). Since it is a list, you can use `append()` to insert properties at the desired place. Let's add `name` as first and `title` as second property:
 
 
-```r
+``` r
 my_package <- append(my_package, c(name = "my_package"), after = 0)
 my_package <- append(my_package, c(title = "My package"), after = 1)
 
@@ -354,16 +364,16 @@ Note that in the above steps you started a Data Package from scratch with `creat
 Now that you have created your Data Package, you can write it to a directory of your choice with `write_package()`:
 
 
-```r
+``` r
 write_package(my_package, "my_directory")
 ```
 
 The directory will contain four files: the descriptor `datapackage.json`, one CSV file containing the data for the resource `iris` and two CSV files containing the data for the resource `observations`.
 
 
-```r
+``` r
 list.files("my_directory")
-#> [1] "datapackage.json"   "iris.csv"           "observations_1.csv" "observations_2.csv"
+#> [1] "datapackage.json"   "iris.csv"           "observations_1.tsv" "observations_2.tsv"
 ```
 
 

--- a/vignettes/frictionless.Rmd
+++ b/vignettes/frictionless.Rmd
@@ -86,13 +86,6 @@ This Data Package has 3 resources. Let's read the data from the `gps` resource i
 
 ``` r
 gps <- read_resource(package, "gps")
-#> Error in `purrr::map_chr()` at frictionless-r/R/get_resource.R:60:7:
-#> ℹ In index: 1.
-#> Caused by error in `check_path()`:
-#> ! Can't find file at <https://zenodo.org/records/10053702/files/O_WESTERSCHELDE-gps-2018.csv.gz>.
-```
-
-``` r
 gps
 #> # A tibble: 73,047 × 21
 #>     `event-id` visible timestamp           `location-long` `location-lat`
@@ -342,7 +335,15 @@ path_2 <- system.file("extdata", "observations_2.tsv", package = "frictionless")
 # Add both TSV files as a single resource
 my_package <-
   my_package %>%
-  add_resource(resource_name = "observations", data = c(path_1, path_2), delim = "\t")
+  add_resource(
+    resource_name = "observations",
+    data = c(path_1, path_2),
+    delim = "\t"
+  )
+#> Error in `purrr::map_chr()` at frictionless-r/R/add_resource.R:132:5:
+#> ℹ In index: 1.
+#> Caused by error in `check_path()`:
+#> ! Can't find file at ''.
 ```
 
 Your Data Package now contains 2 resources, but you can add metadata properties as well (see the [Data Package documentation](https://specs.frictionlessdata.io/data-package/#metadata) for an overview). Since it is a list, you can use `append()` to insert properties at the desired place. Let's add `name` as first and `title` as second property:
@@ -373,7 +374,7 @@ The directory will contain four files: the descriptor `datapackage.json`, one CS
 
 ``` r
 list.files("my_directory")
-#> [1] "datapackage.json"   "iris.csv"           "observations_1.tsv" "observations_2.tsv"
+#> [1] "datapackage.json" "iris.csv"
 ```
 
 

--- a/vignettes/frictionless.Rmd.orig
+++ b/vignettes/frictionless.Rmd.orig
@@ -179,7 +179,11 @@ path_2 <- system.file("extdata", "observations_2.tsv", package = "frictionless")
 # Add both TSV files as a single resource
 my_package <-
   my_package %>%
-  add_resource(resource_name = "observations", data = c(path_1, path_2), delim = "\t")
+  add_resource(
+    resource_name = "observations",
+    data = c(path_1, path_2),
+    delim = "\t"
+  )
 ```
 
 Your Data Package now contains 2 resources, but you can add metadata properties as well (see the [Data Package documentation](https://specs.frictionlessdata.io/data-package/#metadata) for an overview). Since it is a list, you can use `append()` to insert properties at the desired place. Let's add `name` as first and `title` as second property:

--- a/vignettes/frictionless.Rmd.orig
+++ b/vignettes/frictionless.Rmd.orig
@@ -169,17 +169,17 @@ my_package <-
   )
 ```
 
-If you already have your data stored as CSV files and you want to include them _as is_ as a Data Resource, you can do so as well. As with data frames, you can opt to create a Table Schema automatically or provide your own.
+If you already have your data stored as CSV or TSV files and you want to include them _as is_ as a Data Resource, you can do so as well. As with data frames, you can opt to create a Table Schema automatically or provide your own.
 
 ```{r}
-# Two CSV files with the same structure
-path_1 <- system.file("extdata", "observations_1.csv", package = "frictionless")
-path_2 <- system.file("extdata", "observations_2.csv", package = "frictionless")
+# Two TSV files with the same structure
+path_1 <- system.file("extdata", "observations_1.tsv", package = "frictionless")
+path_2 <- system.file("extdata", "observations_2.tsv", package = "frictionless")
 
-# Add both CSV files as a single resource
+# Add both TSV files as a single resource
 my_package <-
   my_package %>%
-  add_resource(resource_name = "observations", data = c(path_1, path_2))
+  add_resource(resource_name = "observations", data = c(path_1, path_2), delim = "\t")
 ```
 
 Your Data Package now contains 2 resources, but you can add metadata properties as well (see the [Data Package documentation](https://specs.frictionlessdata.io/data-package/#metadata) for an overview). Since it is a list, you can use `append()` to insert properties at the desired place. Let's add `name` as first and `title` as second property:


### PR DESCRIPTION
fix #250 

- Some tests failed because they use a link at Github. This can only be tested after merging?
- There is an error at line 88 of `vignettes/frictionless.Rmd` which seems unrelated to #250 ?