### PR TITLE
Quarto callouts

### DIFF
--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -17,7 +17,9 @@ knitr::opts_chunk$set(
 
 [Data Package](https://specs.frictionlessdata.io/data-package/) is a simple container format to describe a coherent collection of data (a dataset), including its contributors, licenses, etc.
 
-_In this document we use the terms "package" for Data Package, "resource" for Data Resource, "dialect" for Table Dialect, and "schema" for Table Schema._
+::: {.callout-info}
+In this document we use the terms "package" for Data Package, "resource" for Data Resource, "dialect" for Table Dialect, and "schema" for Table Schema.
+:::
 
 ## General implementation
 
@@ -65,7 +67,11 @@ invalid_package$resources <- NULL
 check_package(invalid_package)
 ```
 
-You can manipulate the package list, but frictionless does not provide functions to do that. Use `{purrr}` or base R instead (see `vignette("frictionless")`). Note however that some functions (e.g. `unclass()` or `append()`) removes the custom class, creating an invalid package. You can fix this by calling `create_package()` on your package.
+You can manipulate the package list, but frictionless does not provide functions to do that. Use `{purrr}` or base R instead (see `vignette("frictionless")`).
+
+::: {.callout-warning}
+Some functions (e.g. `unclass()` or `append()`) remove the custom class, creating an invalid package. You can fix this by calling `create_package()` on your package.
+:::
 
 Most functions have `package` as their first argument and return package. This allows you to **pipe the functions**:
 

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -17,7 +17,9 @@ knitr::opts_chunk$set(
 
 [Data Resource](https://specs.frictionlessdata.io/data-resource/) is a simple format to describe a data resource such as an individual table or file, including its name, format, path, etc.
 
-_In this document we use the terms "package" for Data Package, "resource" for Data Resource, "dialect" for Table Dialect, and "schema" for Table Schema._
+::: {.callout-info}
+In this document we use the terms "package" for Data Package, "resource" for Data Resource, "dialect" for Table Dialect, and "schema" for Table Schema.
+:::
 
 ## General implementation
 
@@ -65,7 +67,9 @@ path <- system.file("extdata", "v1", "deployments.csv", package = "frictionless"
 add_resource(package, "deployments", data = path, replace = TRUE)
 ```
 
-Note that you can pipe most functions (see `vignette("data-package")`).
+::: {.callout-info}
+You can pipe most functions (see `vignette("data-package")`).
+:::
 
 ### Write
 
@@ -111,7 +115,9 @@ add_resource(package, "deployments", data = path, replace = TRUE)
 
 ### data
 
-_Note: Support for inline `data` is currently limited, e.g. JSON object and string are not supported and `schema`, `mediatype` and `format` are ignored._
+::: {.callout-warning}
+Support for inline `data` is currently limited, e.g. JSON object and string are not supported and `schema`, `mediatype` and `format` are ignored.
+:::
 
 `data` is for inline data (included in the `datapackage.json`). `read_resource()` attempts to read `data` if it is provided as a JSON array:
 

--- a/vignettes/frictionless.Rmd
+++ b/vignettes/frictionless.Rmd
@@ -173,7 +173,9 @@ my_package <-
   add_resource(resource_name = "iris", data = iris)
 ```
 
-Note that you can chain most frictionless functions together using pipes (`%>%` or `|>`), which improves readability.
+::: {.callout-info}
+You can chain most frictionless functions together using pipes (`%>%` or `|>`), which improves readability.
+:::
 
 `my_package` now contains one resource:
 
@@ -349,7 +351,9 @@ my_package <- append(my_package, c(title = "My package"), after = 1)
 my_package <- create_package(my_package)
 ```
 
-Note that in the above steps you started a Data Package from scratch with `create_package()`, but you can use the same functionality to edit an existing Data Package read with `read_package()`.
+::: {.callout-info}
+In the steps above you started a Data Package from scratch with `create_package()`, but you can use the same functionality to edit an existing Data Package read with `read_package()`.
+:::
 
 ## Write a Data Package
 

--- a/vignettes/frictionless.Rmd
+++ b/vignettes/frictionless.Rmd
@@ -303,19 +303,19 @@ str(iris_schema)
 #>   .. ..$ description: chr "Iris species."
 ```
 
-Let's add `iris` as a resource to your Data Package again, but this time with the customized schema. Let's also add `title` and `description` as a metadata properties. Note that you have to remove the originally added resource `iris` with `remove_resource()` first, since Data Packages can only contain uniquely named resources:
+Let's add `iris` as a resource to your Data Package again, but this time with the customized schema. You can replace a resource with `replace = TRUE`. Let's also add `title` and `description` as a metadata properties:
 
 
 ``` r
 my_package <-
   my_package %>%
-  remove_resource("iris") %>% # Remove originally added resource
   add_resource(
     resource_name = "iris",
     data = iris,
     schema = iris_schema, # Your customized schema
     title = "Iris dataset", # Your additional metadata
-    description = "The built-in dataset in R."
+    description = "The built-in dataset in R.",
+    replace = TRUE
   )
 ```
 

--- a/vignettes/frictionless.Rmd.orig
+++ b/vignettes/frictionless.Rmd.orig
@@ -96,7 +96,9 @@ my_package <-
   add_resource(resource_name = "iris", data = iris)
 ```
 
-Note that you can chain most frictionless functions together using pipes (`%>%` or `|>`), which improves readability.
+::: {.callout-info}
+You can chain most frictionless functions together using pipes (`%>%` or `|>`), which improves readability.
+:::
 
 `my_package` now contains one resource:
 
@@ -195,7 +197,9 @@ my_package <- append(my_package, c(title = "My package"), after = 1)
 my_package <- create_package(my_package)
 ```
 
-Note that in the above steps you started a Data Package from scratch with `create_package()`, but you can use the same functionality to edit an existing Data Package read with `read_package()`.
+::: {.callout-info}
+In the steps above you started a Data Package from scratch with `create_package()`, but you can use the same functionality to edit an existing Data Package read with `read_package()`.
+:::
 
 ## Write a Data Package
 

--- a/vignettes/frictionless.Rmd.orig
+++ b/vignettes/frictionless.Rmd.orig
@@ -152,18 +152,18 @@ iris_schema$fields <- purrr::imap(
 str(iris_schema)
 ```
 
-Let's add `iris` as a resource to your Data Package again, but this time with the customized schema. Let's also add `title` and `description` as a metadata properties. Note that you have to remove the originally added resource `iris` with `remove_resource()` first, since Data Packages can only contain uniquely named resources:
+Let's add `iris` as a resource to your Data Package again, but this time with the customized schema. You can replace a resource with `replace = TRUE`. Let's also add `title` and `description` as a metadata properties:
 
 ```{r}
 my_package <-
   my_package %>%
-  remove_resource("iris") %>% # Remove originally added resource
   add_resource(
     resource_name = "iris",
     data = iris,
     schema = iris_schema, # Your customized schema
     title = "Iris dataset", # Your additional metadata
-    description = "The built-in dataset in R."
+    description = "The built-in dataset in R.",
+    replace = TRUE
   )
 ```
 

--- a/vignettes/table-dialect.Rmd
+++ b/vignettes/table-dialect.Rmd
@@ -17,7 +17,9 @@ knitr::opts_chunk$set(
 
 [Table Dialect](https://specs.frictionlessdata.io/csv-dialect/) (previously called CSV dialect) is a simple format to describe the dialect of a tabular data file, including its delimiter, header rows, escape characters, etc.
 
-_In this document we use the terms "package" for Data Package, "resource" for Data Resource, "dialect" for Table Dialect, and "schema" for Table Schema._
+::: {.callout-info}
+In this document we use the terms "package" for Data Package, "resource" for Data Resource, "dialect" for Table Dialect, and "schema" for Table Schema.
+:::
 
 ## General implementation
 
@@ -71,7 +73,11 @@ package$resources[[2]]$dialect$delimiter
 
 ### escapeChar
 
-[`escapeChar`](https://specs.frictionlessdata.io/csv-dialect/#specification) is ignored by `read_resource()` unless it is `"\\"`. It is passed as `escape_backslash = TRUE` and `escape_double = FALSE` in `readr::read_delim()`. Note that `escapeChar` and `doubleQuote` are mutually exclusive, so you cannot escape with `\"` and `""` in the same file.
+[`escapeChar`](https://specs.frictionlessdata.io/csv-dialect/#specification) is ignored by `read_resource()` unless it is `"\\"`. It is passed as `escape_backslash = TRUE` and `escape_double = FALSE` in `readr::read_delim()`.
+
+::: {.callout-warning}
+`escapeChar` and `doubleQuote` are mutually exclusive, so you cannot escape with `\"` and `""` in the same file.
+:::
 
 ### nullSequence
 

--- a/vignettes/table-schema.Rmd
+++ b/vignettes/table-schema.Rmd
@@ -17,7 +17,9 @@ knitr::opts_chunk$set(
 
 [Table Schema](https://specs.frictionlessdata.io/table-schema/) is a simple format to describe tabular data, including field names, types, constraints, missing values, foreign keys, etc.
 
-_In this document we use the terms "package" for Data Package, "resource" for Data Resource, "dialect" for Table Dialect, and "schema" for Table Schema._
+::: {.callout-info}
+In this document we use the terms "package" for Data Package, "resource" for Data Resource, "dialect" for Table Dialect, and "schema" for Table Schema.
+:::
 
 ## General implementation
 


### PR DESCRIPTION
I've been looking for a way to style/highlight notes in the vignettes. This is possible with quarto [callouts](https://quarto.org/docs/authoring/callouts.html):

```
::: {.callout-info}
You can use callouts
:::
```

- In a vignette, this will look as before (regular text)
- In pkgdown, this will look as before, since callouts are [not supported yet](https://pkgdown.r-lib.org/articles/quarto.html?q=callout#limitations), but it seems that will be the case at some point in the future. I don't think we'll have to convert our `.Rmd` to `.qmd`, since a Quarto feature like `[Small caps]{.smallcaps}` already works.

We could already make it work by using:

```
::: {.alert .alert-info}
You can use alerts
:::
```

Which renders like:

<img width="798" alt="Screenshot 2024-09-25 at 14 31 13" src="https://github.com/user-attachments/assets/1d27dda7-ba50-42ad-9220-e355d2aacd35">

But I think it's better to not use this temporary solution, but use callouts. It doesn't affect the readability now + will look better once pkgdown is updated.

---

This PR also updates a step in frictionless.Rmd where a resource is replaced.