### PR TITLE
Attach resource's data

### DIFF
--- a/R/read_package.R
+++ b/R/read_package.R
@@ -56,12 +56,11 @@ read_package <- function(file = "datapackage.json", attach = FALSE) {
   if (attach) {
     package$resources <- purrr::map(package$resources, ~ {
       resource <- get_resource(package, .x$name)
-      if (resource$read_from == "path" || resource$read_from == "url") {
-        df <- read_from_path(package, .x$name, col_select = NULL)
-        .x$data <- df
+      if (resource$read_from %in% c("path", "url")) {
+        .x$data <- read_from_path(package, .x$name, col_select = NULL)
         .x$path <- NULL
       }
-      return(.x)
+      .x
     })
   }
 

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -131,3 +131,17 @@ test_that("read_package() converts JSON null to NULL", {
   # { "image": null } is read as NULL (use chuck() to force error if missing)
   expect_null(purrr::chuck(p, "image"))
 })
+
+
+test_that("read_package() with `attach=TRUE`", {
+  p_path <- system.file("extdata", "v1", "datapackage.json", package = "frictionless")
+  p <- read_package(p_path, attach = TRUE)
+  expect_s3_class(p$resources[[1]]$data, "data.frame")
+
+  p_url <- file.path(
+    "https://raw.githubusercontent.com/frictionlessdata/frictionless-r/",
+    "main/inst/extdata/v1/datapackage.json"
+  )
+  p_remote <- read_package(p_url, attach = TRUE)
+  expect_s3_class(p_remote$resources[[1]]$data, "data.frame")
+})


### PR DESCRIPTION
Here is a small suggest to force the data to be attached to the package object rather than stay as path/url. I would find such a functionality quite useful to be able to work on the data directly, rather than having to read it from elsewhere several time.

This could also be implemented as a seperate function if you think it's better.

Or, is there another way to do that?

If you want to implement this, I'm not sure about `col_select = NULL`. Maybe it should be a different value?

Here is may implementation: https://github.com/Rafnuss/GeoLocatoR/blob/master/R/read_gldp.R#L25-L35. As you can see I depend on `frictionless:::get_resource` and `frictionless:::read_from_path` which is not allowed I think. Any alternative would be great!