### PR TITLE
Remove read_package v2 warning

### DIFF
--- a/R/read_package.R
+++ b/R/read_package.R
@@ -44,16 +44,6 @@ read_package <- function(file = "datapackage.json") {
     )
   }
 
-  # Warn if version >= 1.0
-  version <- version(descriptor)
-  if (version != "1.0") {
-    cli::cli_warn(
-      "This Data Package uses a version ({.field {version}}) not supported by
-       this version of {.pkg frictionless}. Expect errors.",
-      class = "frictionless_warning_version_not_supported"
-    )
-  }
-
   # Add directory
   attr(descriptor, "directory") <- dirname(file) # Also works for URLs
 

--- a/tests/testthat/test-example_package.R
+++ b/tests/testthat/test-example_package.R
@@ -2,12 +2,12 @@ test_that("example_package() allows version selection (default 1.0)", {
   p_v1 <- read_package(
     system.file("extdata", "v1", "datapackage.json", package = "frictionless")
   )
-  p_v2 <- suppressWarnings(read_package(
+  p_v2 <- read_package(
     system.file("extdata", "v2", "datapackage.json", package = "frictionless")
-  ))
+  )
 
   expect_identical(example_package("1.0"), p_v1)
-  expect_identical(suppressWarnings(example_package("2.0")), p_v2)
+  expect_identical(example_package("2.0"), p_v2)
   expect_identical(example_package("not_a_version"), p_v1)
   expect_identical(example_package(version = NULL), p_v1)
 })

--- a/tests/testthat/test-print.datapackage.R
+++ b/tests/testthat/test-print.datapackage.R
@@ -23,7 +23,7 @@ test_that("print.datapackage() informs about the version, resources and
   )
 
   # Version 2.0 with 3 resources
-  p <- suppressWarnings(example_package(version = "2.0"))
+  p <- example_package(version = "2.0")
   expect_output(
     print(p),
     regexp = paste(

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -107,16 +107,6 @@ test_that("read_package() warns if resources are missing", {
   )
 })
 
-test_that("read_package() warns if version is not supported", {
-  expect_no_warning(
-    example_package(version = "1.0")
-  )
-  expect_warning(
-    example_package(version = "2.0"),
-    class = "frictionless_warning_version_not_supported"
-  )
-})
-
 test_that("read_package() allows descriptor at absolute or relative parent
            path", {
   relative_path <- "../testthat/data/valid_minimal.json"

--- a/tests/testthat/test-version.R
+++ b/tests/testthat/test-version.R
@@ -39,6 +39,6 @@ test_that("version() returns >=2.0 for invalid $schema", {
 test_that("version() returns correct version for example packages", {
   p_1.0 <- example_package(version = "1.0")
   expect_equal(version(p_1.0), "1.0")
-  p_2.0 <- suppressWarnings(example_package(version = "2.0"))
+  p_2.0 <- example_package(version = "2.0")
   expect_equal(version(p_2.0), "2.0")
 })


### PR DESCRIPTION
Fix #333

This PR basically reverts https://github.com/frictionlessdata/frictionless-r/pull/309

We aim to support v2, so I'm already removing the warning when reading a v2, to avoid generating lots of WARNs if we move our tests to `example_package(version = "2.0")

Also removes `suppressWarnings()` no longer needed in tests.