### PR TITLE
Update tests in `check_package()`, `remove_resource()` to test both version `1.0` and `2.0` data packages

### DIFF
--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -3,7 +3,7 @@ test_that("check_package() returns package invisibly on valid Data Package", {
   expect_invisible(check_package(p2))
 })
 
-test_that("check_package() returns package as provided", {
+test_that("check_package() returns package (in same version) as provided", {
   p_1 <- example_package(version = "1.0")
   p_2 <- example_package(version = "2.0")
   expect_identical(check_package(p_1), p_1)

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -76,7 +76,7 @@ test_that("check_package() returns error on missing or incorrect directory", {
 })
 
 test_that("check_package() returns deprecation warning for package$directory", {
-  p_directory <- example_package()
+  p_directory <- example_package(version = "2.0")
   p_directory$directory <- attr(p_directory, "directory")
   attr(p_directory, "directory") <- NULL
 
@@ -85,7 +85,7 @@ test_that("check_package() returns deprecation warning for package$directory", {
 })
 
 test_that("check_package() returns error if resources have no name", {
-  p_invalid <- example_package()
+  p_invalid <- example_package(version = "2.0")
   p_invalid$resources[[2]]$name <- NULL
   expect_error(
     check_package(p_invalid),
@@ -98,7 +98,7 @@ test_that("check_package() returns error if resources have no name", {
   )
 
   # Expect no error on empty resources
-  p <- example_package()
+  p <- example_package(version = "2.0")
   p$resources <- list()
   expect_no_error(check_package(p))
 })

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -1,5 +1,5 @@
 test_that("check_package() returns package invisibly on valid Data Package", {
-  p <- example_package()
+  p <- example_package(version = "2.0")
   expect_identical(check_package(p), p)
   expect_invisible(check_package(p))
 })

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -1,5 +1,5 @@
 test_that("check_package() returns package invisibly on valid Data Package", {
-  p <- example_package()
+  p <- example_package(version = "2.0")
   expect_invisible(check_package(p2))
 })
 
@@ -82,7 +82,7 @@ test_that("check_package() returns error on missing or incorrect directory", {
 })
 
 test_that("check_package() returns deprecation warning for package$directory", {
-  p_directory <- example_package()
+  p_directory <- example_package(version = "2.0")
   p_directory$directory <- attr(p_directory, "directory")
   attr(p_directory, "directory") <- NULL
 
@@ -91,7 +91,7 @@ test_that("check_package() returns deprecation warning for package$directory", {
 })
 
 test_that("check_package() returns error if resources have no name", {
-  p_invalid <- example_package()
+  p_invalid <- example_package(version = "2.0")
   p_invalid$resources[[2]]$name <- NULL
   expect_error(
     check_package(p_invalid),
@@ -104,7 +104,7 @@ test_that("check_package() returns error if resources have no name", {
   )
 
   # Expect no error on empty resources
-  p <- example_package()
+  p <- example_package(version = "2.0")
   p$resources <- list()
   expect_no_error(check_package(p))
 })

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -1,5 +1,5 @@
 test_that("check_package() returns package invisibly on valid Data Package", {
-  p <- example_package(version = "2.0")
+  p <- example_package()
   expect_invisible(check_package(p))
 })
 
@@ -82,7 +82,7 @@ test_that("check_package() returns error on missing or incorrect directory", {
 })
 
 test_that("check_package() returns deprecation warning for package$directory", {
-  p_directory <- example_package(version = "2.0")
+  p_directory <- example_package()
   p_directory$directory <- attr(p_directory, "directory")
   attr(p_directory, "directory") <- NULL
 
@@ -91,7 +91,7 @@ test_that("check_package() returns deprecation warning for package$directory", {
 })
 
 test_that("check_package() returns error if resources have no name", {
-  p_invalid <- example_package(version = "2.0")
+  p_invalid <- example_package()
   p_invalid$resources[[2]]$name <- NULL
   expect_error(
     check_package(p_invalid),
@@ -104,7 +104,7 @@ test_that("check_package() returns error if resources have no name", {
   )
 
   # Expect no error on empty resources
-  p <- example_package(version = "2.0")
+  p <- example_package()
   p$resources <- list()
   expect_no_error(check_package(p))
 })

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -1,6 +1,6 @@
 test_that("check_package() returns package invisibly on valid Data Package", {
   p <- example_package(version = "2.0")
-  expect_invisible(check_package(p2))
+  expect_invisible(check_package(p))
 })
 
 test_that("check_package() returns package (in same version) as provided", {

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -82,54 +82,31 @@ test_that("check_package() returns error on missing or incorrect directory", {
 })
 
 test_that("check_package() returns deprecation warning for package$directory", {
-  p1_directory <- example_package(version = "1.0")
-  p1_directory$directory <- attr(p1_directory, "directory")
-  attr(p1_directory, "directory") <- NULL
+  p_directory <- example_package()
+  p_directory$directory <- attr(p_directory, "directory")
+  attr(p_directory, "directory") <- NULL
 
-  lifecycle::expect_deprecated(check_package(p1_directory))
-  expect_no_error(suppressWarnings(check_package(p1_directory)))
-
-  p2_directory <- example_package(version = "2.0")
-  p2_directory$directory <- attr(p2_directory, "directory")
-  attr(p2_directory, "directory") <- NULL
-
-  lifecycle::expect_deprecated(check_package(p2_directory))
-  expect_no_error(suppressWarnings(check_package(p2_directory)))
+  lifecycle::expect_deprecated(check_package(p_directory))
+  expect_no_error(suppressWarnings(check_package(p_directory)))
 })
 
 test_that("check_package() returns error if resources have no name", {
-  p1_invalid <- example_package(version = "1.0")
-  p1_invalid$resources[[2]]$name <- NULL
+  p_invalid <- example_package()
+  p_invalid$resources[[2]]$name <- NULL
   expect_error(
-    check_package(p1_invalid),
+    check_package(p_invalid),
     class = "frictionless_error_resources_without_name"
   )
   expect_error(
-    check_package(p1_invalid),
-    regexp = "All resources in `package` must have a name property.",
-    fixed = TRUE
-  )
-
-  p2_invalid <- example_package(version = "2.0")
-  p2_invalid$resources[[2]]$name <- NULL
-  expect_error(
-    check_package(p2_invalid),
-    class = "frictionless_error_resources_without_name"
-  )
-  expect_error(
-    check_package(p2_invalid),
+    check_package(p_invalid),
     regexp = "All resources in `package` must have a name property.",
     fixed = TRUE
   )
 
   # Expect no error on empty resources
-  p1 <- example_package(version = "1.0")
-  p1$resources <- list()
-  expect_no_error(check_package(p1))
-
-  p2 <- example_package(version = "2.0")
-  p2$resources <- list()
-  expect_no_error(check_package(p2))
+  p <- example_package()
+  p$resources <- list()
+  expect_no_error(check_package(p))
 })
 
 test_that("check_package() returns warning on missing 'datapackage' class", {

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -1,10 +1,13 @@
 test_that("check_package() returns package invisibly on valid Data Package", {
-  p1 <- example_package(version = "1.0")
-  expect_identical(check_package(p1), p1)
-  expect_invisible(check_package(p1))
-  p2 <- example_package(version = "2.0")
-  expect_identical(check_package(p2), p2)
+  p <- example_package()
   expect_invisible(check_package(p2))
+})
+
+test_that("check_package() returns package as provided", {
+  p_1 <- example_package(version = "1.0")
+  p_2 <- example_package(version = "2.0")
+  expect_identical(check_package(p_1), p_1)
+  expect_identical(check_package(p_2), p_2)
 })
 
 test_that("check_package() returns error on invalid Data Package", {

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -4,10 +4,10 @@ test_that("check_package() returns package invisibly on valid Data Package", {
 })
 
 test_that("check_package() returns package (in same version) as provided", {
-  p_1 <- example_package(version = "1.0")
-  p_2 <- example_package(version = "2.0")
-  expect_identical(check_package(p_1), p_1)
-  expect_identical(check_package(p_2), p_2)
+  p_v1 <- example_package(version = "1.0")
+  p_v2 <- example_package(version = "2.0")
+  expect_identical(check_package(p_v1), p_v1)
+  expect_identical(check_package(p_v2), p_v2)
 })
 
 test_that("check_package() returns error on invalid Data Package", {

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -1,7 +1,10 @@
 test_that("check_package() returns package invisibly on valid Data Package", {
-  p <- example_package(version = "2.0")
-  expect_identical(check_package(p), p)
-  expect_invisible(check_package(p))
+  p1 <- example_package(version = "1.0")
+  expect_identical(check_package(p1), p1)
+  expect_invisible(check_package(p1))
+  p2 <- example_package(version = "2.0")
+  expect_identical(check_package(p2), p2)
+  expect_invisible(check_package(p2))
 })
 
 test_that("check_package() returns error on invalid Data Package", {
@@ -76,31 +79,54 @@ test_that("check_package() returns error on missing or incorrect directory", {
 })
 
 test_that("check_package() returns deprecation warning for package$directory", {
-  p_directory <- example_package(version = "2.0")
-  p_directory$directory <- attr(p_directory, "directory")
-  attr(p_directory, "directory") <- NULL
+  p1_directory <- example_package(version = "1.0")
+  p1_directory$directory <- attr(p1_directory, "directory")
+  attr(p1_directory, "directory") <- NULL
 
-  lifecycle::expect_deprecated(check_package(p_directory))
-  expect_no_error(suppressWarnings(check_package(p_directory)))
+  lifecycle::expect_deprecated(check_package(p1_directory))
+  expect_no_error(suppressWarnings(check_package(p1_directory)))
+
+  p2_directory <- example_package(version = "2.0")
+  p2_directory$directory <- attr(p2_directory, "directory")
+  attr(p2_directory, "directory") <- NULL
+
+  lifecycle::expect_deprecated(check_package(p2_directory))
+  expect_no_error(suppressWarnings(check_package(p2_directory)))
 })
 
 test_that("check_package() returns error if resources have no name", {
-  p_invalid <- example_package(version = "2.0")
-  p_invalid$resources[[2]]$name <- NULL
+  p1_invalid <- example_package(version = "1.0")
+  p1_invalid$resources[[2]]$name <- NULL
   expect_error(
-    check_package(p_invalid),
+    check_package(p1_invalid),
     class = "frictionless_error_resources_without_name"
   )
   expect_error(
-    check_package(p_invalid),
+    check_package(p1_invalid),
+    regexp = "All resources in `package` must have a name property.",
+    fixed = TRUE
+  )
+
+  p2_invalid <- example_package(version = "2.0")
+  p2_invalid$resources[[2]]$name <- NULL
+  expect_error(
+    check_package(p2_invalid),
+    class = "frictionless_error_resources_without_name"
+  )
+  expect_error(
+    check_package(p2_invalid),
     regexp = "All resources in `package` must have a name property.",
     fixed = TRUE
   )
 
   # Expect no error on empty resources
-  p <- example_package(version = "2.0")
-  p$resources <- list()
-  expect_no_error(check_package(p))
+  p1 <- example_package(version = "1.0")
+  p1$resources <- list()
+  expect_no_error(check_package(p1))
+
+  p2 <- example_package(version = "2.0")
+  p2$resources <- list()
+  expect_no_error(check_package(p2))
 })
 
 test_that("check_package() returns warning on missing 'datapackage' class", {

--- a/tests/testthat/test-remove_resource.R
+++ b/tests/testthat/test-remove_resource.R
@@ -3,6 +3,13 @@ test_that("remove_resource() returns a valid Data Package", {
   expect_no_error(check_package(remove_resource(p, "deployments")))
 })
 
+test_that("remove_resource() returns package in same version as provided", {
+  p_v1 <- example_package(version = "1.0")
+  p_v2 <- example_package(version = "2.0")
+  expect_identical(version(remove_resource(p_v1, "deployments")), "1.0")
+  expect_identical(version(remove_resource(p_v2, "deployments")), "2.0")
+})
+
 test_that("remove_resource() returns error on invalid Data Package", {
   expect_error(
     remove_resource(list(), "deployments"),
@@ -39,11 +46,4 @@ test_that("remove_resource() removes resource", {
   # Resource removed
   expect_length(p_removed$resources, 2) # Remains a list, now of length 2
   expect_identical(p_removed$resources[[1]][["name"]], "observations")
-})
-
-test_that("remove_resource() returns package in same version as provided", {
-  p_v1 <- example_package(version = "1.0")
-  p_v2 <- example_package(version = "2.0")
-  expect_identical(version(remove_resource(p_1, "deployments")), "1.0")
-  expect_identical(version(remove_resource(p_2, "deployments")), "2.0")
 })

--- a/tests/testthat/test-remove_resource.R
+++ b/tests/testthat/test-remove_resource.R
@@ -3,6 +3,19 @@ test_that("remove_resource() returns a valid Data Package", {
   expect_no_error(check_package(remove_resource(p, "deployments")))
 })
 
+test_that("remove_resource() returns package (in same version) as provided", {
+  p_1 <- example_package(version = "1.0")
+  p_2 <- example_package(version = "2.0")
+  expect_identical(
+    version(remove_resource(p_1, resource_names(p_1)[[1]])),
+    version(p_1)
+  )
+  expect_identical(
+    version(remove_resource(p_2, resource_names(p_2)[[1]])),
+    version(p_2)
+  )
+})
+
 test_that("remove_resource() returns error on invalid Data Package", {
   expect_error(
     remove_resource(list(), "deployments"),

--- a/tests/testthat/test-remove_resource.R
+++ b/tests/testthat/test-remove_resource.R
@@ -42,8 +42,6 @@ test_that("remove_resource() removes resource", {
 })
 
 test_that("remove_resource() returns package (in same version) as provided", {
-  p_1 <- example_package(version = "1.0")
-  p_2 <- example_package(version = "2.0")
   expect_identical(
     version(remove_resource(p_1, resource_names(p_1)[[1]])),
     version(p_1)
@@ -52,4 +50,6 @@ test_that("remove_resource() returns package (in same version) as provided", {
     version(remove_resource(p_2, resource_names(p_2)[[1]])),
     version(p_2)
   )
+  p_v1 <- example_package(version = "1.0")
+  p_v2 <- example_package(version = "2.0")
 })

--- a/tests/testthat/test-remove_resource.R
+++ b/tests/testthat/test-remove_resource.R
@@ -1,5 +1,5 @@
 test_that("remove_resource() returns a valid Data Package", {
-  p <- example_package()
+  p <- example_package(version = "2.0")
   expect_no_error(check_package(remove_resource(p, "deployments")))
 })
 

--- a/tests/testthat/test-remove_resource.R
+++ b/tests/testthat/test-remove_resource.R
@@ -3,19 +3,6 @@ test_that("remove_resource() returns a valid Data Package", {
   expect_no_error(check_package(remove_resource(p, "deployments")))
 })
 
-test_that("remove_resource() returns package (in same version) as provided", {
-  p_1 <- example_package(version = "1.0")
-  p_2 <- example_package(version = "2.0")
-  expect_identical(
-    version(remove_resource(p_1, resource_names(p_1)[[1]])),
-    version(p_1)
-  )
-  expect_identical(
-    version(remove_resource(p_2, resource_names(p_2)[[1]])),
-    version(p_2)
-  )
-})
-
 test_that("remove_resource() returns error on invalid Data Package", {
   expect_error(
     remove_resource(list(), "deployments"),
@@ -52,4 +39,17 @@ test_that("remove_resource() removes resource", {
   # Resource removed
   expect_length(p_removed$resources, 2) # Remains a list, now of length 2
   expect_identical(p_removed$resources[[1]][["name"]], "observations")
+})
+
+test_that("remove_resource() returns package (in same version) as provided", {
+  p_1 <- example_package(version = "1.0")
+  p_2 <- example_package(version = "2.0")
+  expect_identical(
+    version(remove_resource(p_1, resource_names(p_1)[[1]])),
+    version(p_1)
+  )
+  expect_identical(
+    version(remove_resource(p_2, resource_names(p_2)[[1]])),
+    version(p_2)
+  )
 })

--- a/tests/testthat/test-remove_resource.R
+++ b/tests/testthat/test-remove_resource.R
@@ -1,5 +1,5 @@
 test_that("remove_resource() returns a valid Data Package", {
-  p <- example_package(version = "2.0")
+  p <- example_package()
   expect_no_error(check_package(remove_resource(p, "deployments")))
 })
 

--- a/tests/testthat/test-remove_resource.R
+++ b/tests/testthat/test-remove_resource.R
@@ -41,15 +41,9 @@ test_that("remove_resource() removes resource", {
   expect_identical(p_removed$resources[[1]][["name"]], "observations")
 })
 
-test_that("remove_resource() returns package (in same version) as provided", {
-  expect_identical(
-    version(remove_resource(p_1, resource_names(p_1)[[1]])),
-    version(p_1)
-  )
-  expect_identical(
-    version(remove_resource(p_2, resource_names(p_2)[[1]])),
-    version(p_2)
-  )
+test_that("remove_resource() returns package in same version as provided", {
   p_v1 <- example_package(version = "1.0")
   p_v2 <- example_package(version = "2.0")
+  expect_identical(version(remove_resource(p_1, "deployments")), "1.0")
+  expect_identical(version(remove_resource(p_2, "deployments")), "2.0")
 })

--- a/tests/testthat/test-version.R
+++ b/tests/testthat/test-version.R
@@ -131,29 +131,29 @@ test_that("version() returns >=2.0 for invalid $schema", {
 })
 
 test_that("version() returns correct version for example package properties", {
-  p_1.0 <- example_package(version = "1.0")
+  p_v1 <- example_package(version = "1.0")
 
   # Data Package
-  expect_equal(version(p_1.0), "1.0")
+  expect_equal(version(p_v1), "1.0")
   # Data Resource
-  expect_equal(version(p_1.0$resources[[1]]), "1.0")
+  expect_equal(version(p_v1$resources[[1]]), "1.0")
   # Data Dialect (undefined for deployments)
-  expect_equal(version(p_1.0$resources[[1]]$dialect), "1.0")
+  expect_equal(version(p_v1$resources[[1]]$dialect), "1.0")
   # Table Dialect (defined for observations)
-  expect_equal(version(p_1.0$resources[[2]]$dialect), "1.0")
+  expect_equal(version(p_v1$resources[[2]]$dialect), "1.0")
   # Table Schema
-  expect_equal(version(p_1.0$resources[[1]]$schema), "1.0")
+  expect_equal(version(p_v1$resources[[1]]$schema), "1.0")
 
-  p_2.0 <- example_package(version = "2.0")
+  p_v2 <- example_package(version = "2.0")
 
   # Data Package
-  expect_equal(version(p_2.0), "2.0")
+  expect_equal(version(p_v2), "2.0")
   # Data Resource
-  expect_equal(version(p_2.0$resources[[1]]), "2.0")
+  expect_equal(version(p_v2$resources[[1]]), "2.0")
   # Data Dialect (undefined for deployments)
-  expect_equal(version(p_2.0$resources[[1]]$dialect), "1.0")
+  expect_equal(version(p_v2$resources[[1]]$dialect), "1.0")
   # Table Dialect (defined for observations)
-  expect_equal(version(p_2.0$resources[[2]]$dialect), "2.0")
+  expect_equal(version(p_v2$resources[[2]]$dialect), "2.0")
   # Table Schema
-  expect_equal(version(p_2.0$resources[[1]]$schema), "2.0")
+  expect_equal(version(p_v2$resources[[1]]$schema), "2.0")
 })


### PR DESCRIPTION
Fix #329 

I've doubled up on the tests so both version 1 and version 2 are now tested. Tests pass. 

No changes to the internals to `check_package()` were necessary for the current functionality. 

## TODO

- [x] Add identical test for `remove_resource()`
- [x] Revert double tests for v1, v2