### PR TITLE
Migrate `check_schema()` to v2

### DIFF
--- a/tests/testthat/test-check_schema.R
+++ b/tests/testthat/test-check_schema.R
@@ -1,5 +1,5 @@
 test_that("check_schema() returns schema invisibly on valid Table Schema", {
-  p <- example_package(version = "2.0")
+  p <- example_package()
 
   # Can't obtain df using read_resource(), because that function uses
   # check_schema() (in schema()) internally, which is what we want to test
@@ -23,19 +23,14 @@ test_that("check_schema() returns schema invisibly on valid Table Schema", {
 })
 
 test_that("check_schema() returns schema (in same version) as provided", {
-  s_v1 <-
-    schema(
-      example_package(version = "1.0"),
-      resource_names(example_package(version = "1.0"))[[1]]
-    )
-  s_v2 <-
-    schema(
-      example_package(version = "2.0"),
-      resource_names(example_package(version = "2.0"))[[1]]
-    )
+  # This tests these expectations for both schema() and check_schema()
+  schema_v1 <- schema(example_package(version = "1.0"), "deployments")
+  schema_v2 <- schema(example_package(version = "2.0"), "deployments")
 
-  expect_identical(version(check_schema(s_v1)), version(s_v1))
-  expect_identical(version(check_schema(s_v2)), version(s_v2))
+  expect_identical(version(check_schema(schema_v1)), "1.0") # No silent upgrade
+  expect_identical(check_schema(schema_v1), schema_v1)
+  expect_identical(version(check_schema(schema_v2)), "2.0")
+  expect_identical(check_schema(schema_v2), schema_v2)
 })
 
 test_that("check_schema() returns error on invalid or empty Table Schema", {

--- a/tests/testthat/test-check_schema.R
+++ b/tests/testthat/test-check_schema.R
@@ -22,6 +22,22 @@ test_that("check_schema() returns schema invisibly on valid Table Schema", {
   expect_invisible(check_schema(schema_create, df))
 })
 
+test_that("check_schema() returns schema (in same version) as provided", {
+  s_v1 <-
+    schema(
+      example_package(version = "1.0"),
+      resource_names(example_package(version = "1.0"))[[1]]
+    )
+  s_v2 <-
+    schema(
+      example_package(version = "2.0"),
+      resource_names(example_package(version = "2.0"))[[1]]
+    )
+
+  expect_identical(version(check_schema(s_v1)), version(s_v1))
+  expect_identical(version(check_schema(s_v2)), version(s_v2))
+})
+
 test_that("check_schema() returns error on invalid or empty Table Schema", {
   # Must be a list and have list property "fields"
   expect_error(

--- a/tests/testthat/test-check_schema.R
+++ b/tests/testthat/test-check_schema.R
@@ -1,5 +1,5 @@
 test_that("check_schema() returns schema invisibly on valid Table Schema", {
-  p <- example_package()
+  p <- example_package(version = "2.0")
 
   # Can't obtain df using read_resource(), because that function uses
   # check_schema() (in schema()) internally, which is what we want to test


### PR DESCRIPTION
Fix #330 

- I set the `example_package()` to be used to test invisible return to version 2.0
- I checked if the returned schema matches the input schema, this also tests `schema()´: related to #328