### PR TITLE
Migrate `resource()` and `resource()<-` to v2

### DIFF
--- a/tests/testthat/test-add_resource.R
+++ b/tests/testthat/test-add_resource.R
@@ -1,4 +1,4 @@
-test_that("add_resource() returns a valid Data Package", {
+test_that("add_resource() returns a valid package", {
   p <- example_package()
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
   df_csv <- test_path("data/df.csv")
@@ -11,7 +11,7 @@ test_that("add_resource() returns a valid Data Package", {
   ))
 })
 
-test_that("add_resource() returns error on invalid Data Package", {
+test_that("add_resource() returns error on package", {
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
   expect_error(
     add_resource(list(), "new", df),

--- a/tests/testthat/test-add_resource.R
+++ b/tests/testthat/test-add_resource.R
@@ -290,6 +290,7 @@ test_that("add_resource() uses provided schema (list or path) or creates one", {
 })
 
 test_that("add_resource() keeps URL schema as URL", {
+  skip_if_offline()
   p <- example_package()
   deployments <- read_resource(p, "deployments")
   schema_url <- file.path(

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -3,11 +3,11 @@ test_that("check_package() returns package invisibly on valid Data Package", {
   expect_invisible(check_package(p))
 })
 
-test_that("check_package() returns package (in same version) as provided", {
+test_that("check_package() returns package in same version as provided", {
   p_v1 <- example_package(version = "1.0")
   p_v2 <- example_package(version = "2.0")
-  expect_identical(check_package(p_v1), p_v1)
-  expect_identical(check_package(p_v2), p_v2)
+  expect_identical(version(check_package(p_v1)), "1.0")
+  expect_identical(version(check_package(p_v2)), "2.0")
 })
 
 test_that("check_package() returns error on invalid Data Package", {

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -1,4 +1,4 @@
-test_that("check_package() returns package invisibly on valid Data Package", {
+test_that("check_package() returns package invisibly on valid package", {
   p <- example_package()
   expect_invisible(check_package(p))
 })
@@ -10,7 +10,7 @@ test_that("check_package() returns package in same version as provided", {
   expect_identical(version(check_package(p_v2)), "2.0")
 })
 
-test_that("check_package() returns error on invalid Data Package", {
+test_that("check_package() returns error on invalid package", {
   expect_error(
     check_package("not_valid"),
     class = "frictionless_error_package_invalid"

--- a/tests/testthat/test-check_schema.R
+++ b/tests/testthat/test-check_schema.R
@@ -22,15 +22,12 @@ test_that("check_schema() returns schema invisibly on valid Table Schema", {
   expect_invisible(check_schema(schema_create, df))
 })
 
-test_that("check_schema() returns schema (in same version) as provided", {
+test_that("check_schema() returns schema in same version as provided", {
   # This tests these expectations for both schema() and check_schema()
   schema_v1 <- schema(example_package(version = "1.0"), "deployments")
   schema_v2 <- schema(example_package(version = "2.0"), "deployments")
-
-  expect_identical(version(check_schema(schema_v1)), "1.0") # No silent upgrade
-  expect_identical(check_schema(schema_v1), schema_v1)
+  expect_identical(version(check_schema(schema_v1)), "1.0")
   expect_identical(version(check_schema(schema_v2)), "2.0")
-  expect_identical(check_schema(schema_v2), schema_v2)
 })
 
 test_that("check_schema() returns error on invalid or empty Table Schema", {

--- a/tests/testthat/test-check_schema.R
+++ b/tests/testthat/test-check_schema.R
@@ -1,4 +1,4 @@
-test_that("check_schema() returns schema invisibly on valid Table Schema", {
+test_that("check_schema() returns schema invisibly on valid schema", {
   p <- example_package()
 
   # Can't obtain df using read_resource(), because that function uses
@@ -30,7 +30,7 @@ test_that("check_schema() returns schema in same version as provided", {
   expect_identical(version(check_schema(schema_v2)), "2.0")
 })
 
-test_that("check_schema() returns error on invalid or empty Table Schema", {
+test_that("check_schema() returns error on invalid or empty schema", {
   # Must be a list and have list property "fields"
   expect_error(
     check_schema("not_a_list"),
@@ -47,8 +47,7 @@ test_that("check_schema() returns error on invalid or empty Table Schema", {
   )
 })
 
-test_that("check_schema() returns error when Table Schema fields don't have
-           names", {
+test_that("check_schema() returns error when schema fields don't have names", {
   # One missing name
   invalid_schema <- list(fields = list(
     list(name = "col_1", type = "number"),
@@ -85,8 +84,7 @@ test_that("check_schema() returns error when Table Schema fields don't have
   )
 })
 
-test_that("check_schema() returns error when Table Schema fields have invalid
-           types", {
+test_that("check_schema() returns error when schema fields have invalid types", {
   # One invalid types
   invalid_schema <- list(fields = list(
     list(name = "col_1", type = "number"),
@@ -122,7 +120,7 @@ test_that("check_schema() returns error when Table Schema fields have invalid
   )
 })
 
-test_that("check_schema() allows Table Schema fields to not (all) have type", {
+test_that("check_schema() allows schema fields to not (all) have type", {
   schema <- list(fields = list(
     list(name = "col_1"),
     list(name = "col_2")

--- a/tests/testthat/test-create_schema.R
+++ b/tests/testthat/test-create_schema.R
@@ -1,4 +1,4 @@
-test_that("create_schema() returns a valid Table Schema", {
+test_that("create_schema() returns a valid schema", {
   df <- data.frame(
     "col_1" = c(1, 2),
     "col_2" = factor(c("a", "b"), levels = c("a", "b", "c"))

--- a/tests/testthat/test-print.datapackage.R
+++ b/tests/testthat/test-print.datapackage.R
@@ -8,9 +8,9 @@ test_that("print.datapackage() informs about the version, resources and
   unclass_message <- "Use `unclass()` to print the Data Package as a list."
 
   # Version 1.0 with 3 resources
-  p <- example_package(version = "1.0")
+  p_v1 <- example_package(version = "1.0")
   expect_output(
-    print(p),
+    print(p_v1),
     regexp = paste(
       "A Data Package (version 1.0) with 3 resources:",
       "* deployments",
@@ -23,9 +23,9 @@ test_that("print.datapackage() informs about the version, resources and
   )
 
   # Version 2.0 with 3 resources
-  p <- example_package(version = "2.0")
+  p_v2 <- example_package(version = "2.0")
   expect_output(
-    print(p),
+    print(p_v2),
     regexp = paste(
       "A Data Package (version 2.0) with 3 resources:",
       "* deployments",

--- a/tests/testthat/test-read_package.R
+++ b/tests/testthat/test-read_package.R
@@ -1,4 +1,4 @@
-test_that("read_package() returns a valid Data Package reading from path", {
+test_that("read_package() returns a valid package reading from path", {
   # Load example package and a valid minimal one
   p_path <- system.file("extdata", "v1", "datapackage.json", package = "frictionless")
   minimal_path <- test_path("data/valid_minimal.json")
@@ -22,7 +22,7 @@ test_that("read_package() returns a valid Data Package reading from path", {
   expect_identical(attr(p_minimal, "directory"), "data")
 })
 
-test_that("read_package() returns a valid Data Package reading from url", {
+test_that("read_package() returns a valid package reading from url", {
   skip_if_offline()
   # Load example package remotely
   p_url <- file.path(

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -111,7 +111,7 @@ test_that("read_resource() returns error on column selection not in schema", {
   )
 })
 
-test_that("read_resource() returns error on invalid Data Package", {
+test_that("read_resource() returns error on invalid package", {
   expect_error(
     read_resource(list(), "deployments"),
     class = "frictionless_error_package_invalid"
@@ -292,8 +292,8 @@ test_that("read_resource() can read remote files", {
   expect_identical(read_resource(p_remote_resource, "deployments"), resource)
 })
 
-test_that("read_resource() can read safe local and remote Table Schema,
-           including YAML", {
+test_that("read_resource() can read safe local and remote schema, including
+           YAML", {
   skip_if_offline()
   p <- example_package()
   resource <- read_resource(p, "deployments")

--- a/tests/testthat/test-remove_resource.R
+++ b/tests/testthat/test-remove_resource.R
@@ -1,4 +1,4 @@
-test_that("remove_resource() returns a valid Data Package", {
+test_that("remove_resource() returns a valid package", {
   p <- example_package()
   expect_no_error(check_package(remove_resource(p, "deployments")))
 })
@@ -10,7 +10,7 @@ test_that("remove_resource() returns package in same version as provided", {
   expect_identical(version(remove_resource(p_v2, "deployments")), "2.0")
 })
 
-test_that("remove_resource() returns error on invalid Data Package", {
+test_that("remove_resource() returns error on invalid package", {
   expect_error(
     remove_resource(list(), "deployments"),
     class = "frictionless_error_package_invalid"

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -28,6 +28,26 @@ test_that("resource() returns resource (in same version) as provided", {
   )
 })
 
+test_that("resource()<- returns schema (in same version) as provided", {
+  skip_if_offline()
+
+  p_v1_assign <- p_v1 <- example_package(version = "1.0")
+  resource(p_v1_assign, "deployments")$name <- "custom name"
+
+  expect_identical(
+    version(resource(p_v1, "deployments")),
+    version(resource(p_v1_assign, "custom name"))
+  )
+
+  p_v2_assign <- p_v2 <- example_package(version = "2.0")
+  resource(p_v2_assign, "deployments")$name <- "custom name"
+
+  expect_identical(
+    version(resource(p_v2, "deployments")),
+    version(resource(p_v2_assign, "custom name"))
+  )
+})
+
 test_that("resource()<- returns a Data Package invisibly", {
   skip_if_offline()
   p <- example_package()

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -10,7 +10,7 @@ test_that("resource() can upgrade a resource from v1 to v2", {
   expect_identical(version(resource(p_v2, "deployments", upgrade = TRUE)), "2.0")
 })
 
-test_that("resource() returns resource (in same version) as provided", {
+test_that("resource() returns resource in same version as provided", {
   p_v1 <- example_package(version = "1.0")
   expect_identical(
     version(resource(p_v1, "deployments")),
@@ -24,7 +24,6 @@ test_that("resource() returns resource (in same version) as provided", {
   )
 })
 
-test_that("resource()<- returns schema (in same version) as provided", {
   p_v1_assign <- p_v1 <- example_package(version = "1.0")
   resource(p_v1_assign, "deployments")$name <- "custom name"
 
@@ -35,6 +34,8 @@ test_that("resource()<- returns schema (in same version) as provided", {
 
   p_v2_assign <- p_v2 <- example_package(version = "2.0")
   resource(p_v2_assign, "deployments")$name <- "custom name"
+test_that("resource()<- returns package and resource in same version as
+           provided", {
 
   expect_identical(
     version(resource(p_v2, "deployments")),

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -1,6 +1,4 @@
 test_that("resource() can upgrade a resource from v1 to v2", {
-  skip_if_offline()
-
   # Upgrade v1 if asked
   p_v1 <- example_package(version = "1.0")
   expect_identical(version(resource(p_v1, "deployments")), "1.0")
@@ -13,8 +11,6 @@ test_that("resource() can upgrade a resource from v1 to v2", {
 })
 
 test_that("resource() returns resource (in same version) as provided", {
-  skip_if_offline()
-
   p_v1 <- example_package(version = "1.0")
   expect_identical(
     version(resource(p_v1, "deployments")),
@@ -29,8 +25,6 @@ test_that("resource() returns resource (in same version) as provided", {
 })
 
 test_that("resource()<- returns schema (in same version) as provided", {
-  skip_if_offline()
-
   p_v1_assign <- p_v1 <- example_package(version = "1.0")
   resource(p_v1_assign, "deployments")$name <- "custom name"
 
@@ -49,7 +43,6 @@ test_that("resource()<- returns schema (in same version) as provided", {
 })
 
 test_that("resource()<- returns a Data Package invisibly", {
-  skip_if_offline()
   p <- example_package()
   expect_invisible(resource(p, "deployments") <- list(name = "deployments"))
 })
@@ -63,7 +56,6 @@ test_that("resource()<- returns error on invalid Data Package", {
 })
 
 test_that("resource()<- returns error when resource not found", {
-  skip_if_offline()
   p <- example_package()
   expect_error(
     resource(p, "no_such_resource") <- list(name = "assigned"),
@@ -72,7 +64,6 @@ test_that("resource()<- returns error when resource not found", {
 })
 
 test_that("resource()<- allows overwriting a resource", {
-  skip_if_offline()
   p <- example_package()
   resource <- resource(p, "deployments")
   resource$title <- "Custom title"
@@ -81,14 +72,12 @@ test_that("resource()<- allows overwriting a resource", {
 })
 
 test_that("resource()$property<- allows overwriting a resource property", {
-  skip_if_offline()
   p <- example_package()
   resource(p, "deployments")$title <- "Custom title"
   expect_identical(p$resources[[1]]$title, "Custom title")
 })
 
 test_that("resource()<- allows overwriting with NULL, removing the resource", {
-  skip_if_offline()
   p <- p_assigned <- example_package()
   resource(p_assigned, "deployments") <- NULL
   expect_identical(
@@ -98,7 +87,6 @@ test_that("resource()<- allows overwriting with NULL, removing the resource", {
 })
 
 test_that("resource()<- allows overwriting a resource with a different name", {
-  skip_if_offline()
   p <- example_package()
   resource(p, "deployments") <- list(name = "not_deployments")
   expect_identical(

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -30,12 +30,12 @@ test_that("resource()<- returns package and resource in same version as
   expect_identical(version(resource(p_v2, "custom_name")), "2.0")
 })
 
-test_that("resource()<- returns a Data Package invisibly", {
+test_that("resource()<- returns a package invisibly", {
   p <- example_package()
   expect_invisible(resource(p, "deployments") <- list(name = "deployments"))
 })
 
-test_that("resource()<- returns error on invalid Data Package", {
+test_that("resource()<- returns error on invalid package", {
   p_invalid <- list()
   expect_error(
     resource(p_invalid, "assigned") <- list(name = "assigned"),

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -12,16 +12,9 @@ test_that("resource() can upgrade a resource from v1 to v2", {
 
 test_that("resource() returns resource in same version as provided", {
   p_v1 <- example_package(version = "1.0")
-  expect_identical(
-    version(resource(p_v1, "deployments")),
-    version(p_v1)
-  )
-
   p_v2 <- example_package(version = "2.0")
-  expect_identical(
-    version(resource(p_v2, "deployments")),
-    version(p_v2)
-  )
+  expect_identical(version(resource(p_v1, "deployments")), "1.0")
+  expect_identical(version(resource(p_v2, "deployments")), "2.0")
 })
 
   p_v1_assign <- p_v1 <- example_package(version = "1.0")

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -12,6 +12,22 @@ test_that("resource() can upgrade a resource from v1 to v2", {
   expect_identical(version(resource(p_v2, "deployments", upgrade = TRUE)), "2.0")
 })
 
+test_that("resource() returns resource (in same version) as provided", {
+  skip_if_offline()
+
+  p_v1 <- example_package(version = "1.0")
+  expect_identical(
+    version(resource(p_v1, "deployments")),
+    version(p_v1)
+  )
+
+  p_v2 <- example_package(version = "2.0")
+  expect_identical(
+    version(resource(p_v2, "deployments")),
+    version(p_v2)
+  )
+})
+
 test_that("resource()<- returns a Data Package invisibly", {
   skip_if_offline()
   p <- example_package()

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -17,23 +17,17 @@ test_that("resource() returns resource in same version as provided", {
   expect_identical(version(resource(p_v2, "deployments")), "2.0")
 })
 
-  p_v1_assign <- p_v1 <- example_package(version = "1.0")
-  resource(p_v1_assign, "deployments")$name <- "custom name"
-
-  expect_identical(
-    version(resource(p_v1, "deployments")),
-    version(resource(p_v1_assign, "custom name"))
-  )
-
-  p_v2_assign <- p_v2 <- example_package(version = "2.0")
-  resource(p_v2_assign, "deployments")$name <- "custom name"
 test_that("resource()<- returns package and resource in same version as
            provided", {
+  p_v1 <- example_package(version = "1.0")
+  p_v2 <- example_package(version = "2.0")
+  resource(p_v1, "deployments")$name <- "custom_name"
+  resource(p_v2, "deployments")$name <- "custom_name"
 
-  expect_identical(
-    version(resource(p_v2, "deployments")),
-    version(resource(p_v2_assign, "custom name"))
-  )
+  expect_identical(version(p_v1), "1.0")
+  expect_identical(version(resource(p_v1, "custom_name")), "1.0")
+  expect_identical(version(p_v2), "2.0")
+  expect_identical(version(resource(p_v2, "custom_name")), "2.0")
 })
 
 test_that("resource()<- returns a Data Package invisibly", {

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -2,7 +2,7 @@ test_that("resource() can upgrade a resource from v1 to v2", {
   skip_if_offline()
 
   # Upgrade v1 if asked
-  p_v1 <- example_package()
+  p_v1 <- example_package(version = "1.0")
   expect_identical(version(resource(p_v1, "deployments")), "1.0")
   expect_identical(version(resource(p_v1, "deployments", upgrade = TRUE)), "2.0")
 

--- a/tests/testthat/test-version.R
+++ b/tests/testthat/test-version.R
@@ -1,4 +1,4 @@
-test_that("version() returns correct version for Data Package", {
+test_that("version() returns correct version for package", {
   package <- create_package()
 
   # Undefined $schema
@@ -28,7 +28,7 @@ test_that("version() returns correct version for Data Package", {
   expect_identical(version(package), ">=2.0")
 })
 
-test_that("version() returns correct version for Data Resource", {
+test_that("version() returns correct version for resource", {
   resource <- list(
     name = "custom_resource",
     path = "https://example.com/data.csv"
@@ -59,7 +59,7 @@ test_that("version() returns correct version for Data Resource", {
   expect_identical(version(resource), ">=2.0")
 })
 
-test_that("version() returns correct version for Table Dialect", {
+test_that("version() returns correct version for dialect", {
   # Entire dialect undefined => $schema is undefined => 1.0
   dialect <- NULL
   expect_identical(version(dialect), "1.0")
@@ -92,7 +92,7 @@ test_that("version() returns correct version for Table Dialect", {
   expect_identical(version(dialect), ">=2.0")
 })
 
-test_that("version() returns correct version for Table Schema", {
+test_that("version() returns correct version for schema", {
   schema <- list(
     fields = list()
   )

--- a/tests/testthat/test-write_package.R
+++ b/tests/testthat/test-write_package.R
@@ -1,4 +1,4 @@
-test_that("write_package() returns output Data Package (invisibly)", {
+test_that("write_package() returns output package (invisibly)", {
   p <- example_package()
 
   # Note write_package() is expected to create directory without warning
@@ -14,14 +14,14 @@ test_that("write_package() returns output Data Package (invisibly)", {
   expect_identical(p_written, p_from_file)
 })
 
-test_that("write_package() returns error on invalid Data Package", {
+test_that("write_package() returns error on invalid package", {
   expect_error(
     write_package(list()),
     class = "frictionless_error_package_invalid"
   )
 })
 
-test_that("write_package() returns error if Data Package has no resource(s)", {
+test_that("write_package() returns error if package has no resource(s)", {
   p_empty <- create_package()
   dir <- file.path(tempdir(), "package")
   on.exit(unlink(dir, recursive = TRUE))


### PR DESCRIPTION
Fix #327

- I spotted that one test needed the default version of `example_package()´ to be 1.0, so I added the version argument to make this stable 
- I added tests to see if ´resource()´ and ´resource()<-´ return the same resource versions as their inputs. 