### PR TITLE
Remove parameter `upgrade` in `resource()`

### DIFF
--- a/R/resource.R
+++ b/R/resource.R
@@ -23,8 +23,6 @@
 #' See `vignette("data-resource")` to learn more about Data Resource.
 #'
 #' @inheritParams read_resource
-#' @param upgrade If `TRUE`, updates a Data Resource defined in Data Package
-#'   standard v1 to v2.
 #' @returns List describing a Data Resource.
 #' @family accessor functions
 #' @export
@@ -44,7 +42,7 @@
 #'
 #' # Updating a resource property can also be done in one step
 #' resource(package, "deployments")$description <- "Table with deployments."
-resource <- function(package, resource_name, upgrade = FALSE) {
+resource <- function(package, resource_name) {
   # Check package
   check_package(package)
 
@@ -62,11 +60,6 @@ resource <- function(package, resource_name, upgrade = FALSE) {
 
   # Get resource
   resource <- purrr::keep(package$resources, ~ .x$name == resource_name)[[1]]
-
-  # Upgrade resource
-  if (upgrade) {
-    resource <- upgrade_resource(resource)
-  }
 
   # Check that path or data are set
   # https://specs.frictionlessdata.io/data-resource/#data-location

--- a/man/resource.Rd
+++ b/man/resource.Rd
@@ -5,7 +5,7 @@
 \alias{resource<-}
 \title{Get or overwrite a Data Resource}
 \usage{
-resource(package, resource_name, upgrade = FALSE)
+resource(package, resource_name)
 
 resource(package, resource_name) <- value
 }
@@ -14,9 +14,6 @@ resource(package, resource_name) <- value
 \code{\link[=create_package]{create_package()}}.}
 
 \item{resource_name}{Name of the Data Resource.}
-
-\item{upgrade}{If \code{TRUE}, updates a Data Resource defined in Data Package
-standard v1 to v2.}
 
 \item{value}{Value to assign.}
 }

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -1,15 +1,3 @@
-test_that("resource() can upgrade a resource from v1 to v2", {
-  # Upgrade v1 if asked
-  p_v1 <- example_package(version = "1.0")
-  expect_identical(version(resource(p_v1, "deployments")), "1.0")
-  expect_identical(version(resource(p_v1, "deployments", upgrade = TRUE)), "2.0")
-
-  # Leave v2 as is
-  p_v2 <- example_package(version = "2.0")
-  expect_identical(version(resource(p_v2, "deployments")), "2.0")
-  expect_identical(version(resource(p_v2, "deployments", upgrade = TRUE)), "2.0")
-})
-
 test_that("resource() returns resource in same version as provided", {
   p_v1 <- example_package(version = "1.0")
   p_v2 <- example_package(version = "2.0")


### PR DESCRIPTION
It was decided to not use `upgrade` parameters within functions.