### PR TITLE
Create append helper function and set $schema as first attribute

### DIFF
--- a/R/upgrade_descriptor.R
+++ b/R/upgrade_descriptor.R
@@ -14,9 +14,12 @@ upgrade_descriptor <- function(package) {
     return(package)
   }
 
-  # Set $schema
-  purrr::pluck(package, "$schema") <-
-    "https://datapackage.org/profiles/2.0/datapackage.json"
+  # Set $schema as first property
+  package <- append_with_attrs(
+    package,
+    list("$schema" = "https://datapackage.org/profiles/2.0/datapackage.json"),
+    after = 0
+  )
 
   # Set $schema to profile if URL (to custom profile)
   profile <- package$profile %||% "undefined"

--- a/R/upgrade_descriptor.R
+++ b/R/upgrade_descriptor.R
@@ -15,7 +15,7 @@ upgrade_descriptor <- function(package) {
   }
 
   # Set $schema as first property
-  package <- append_with_attrs(
+  package <- append_with_attributes(
     package,
     list("$schema" = "https://datapackage.org/profiles/2.0/datapackage.json"),
     after = 0

--- a/R/upgrade_resource.R
+++ b/R/upgrade_resource.R
@@ -12,9 +12,12 @@ upgrade_resource <- function(resource) {
     return(resource)
   }
 
-  # Set $schema
-  purrr::pluck(resource, "$schema") <-
-    "https://datapackage.org/profiles/2.0/dataresource.json"
+  # Set $schema as first property
+  resource <- append_with_attrs(
+    resource,
+    list("$schema" = "https://datapackage.org/profiles/2.0/dataresource.json"),
+    after = 0
+  )
 
   # Set type to table if resource is tabular, see
   # https://datapackage.org/standard/data-resource/#type

--- a/R/upgrade_resource.R
+++ b/R/upgrade_resource.R
@@ -13,7 +13,7 @@ upgrade_resource <- function(resource) {
   }
 
   # Set $schema as first property
-  resource <- append_with_attrs(
+  resource <- append_with_attributes(
     resource,
     list("$schema" = "https://datapackage.org/profiles/2.0/dataresource.json"),
     after = 0

--- a/R/upgrade_schema.R
+++ b/R/upgrade_schema.R
@@ -14,9 +14,12 @@ upgrade_schema <- function(schema, resource_name) {
     return(schema)
   }
 
-  # Set $schema
-  purrr::pluck(schema, "$schema") <-
-    "https://datapackage.org/profiles/2.0/tableschema.json"
+  # Set $schema as first property
+  schema <- append_with_attributes(
+    schema,
+    list("$schema" = "https://datapackage.org/profiles/2.0/tableschema.json"),
+    after = 0
+  )
 
   # Update primaryKey to array
   # https://datapackage.org/overview/changelog/#schemaprimarykey-updated

--- a/R/utils.R
+++ b/R/utils.R
@@ -90,3 +90,28 @@ get_dot_names <- function(...) {
   # Return the names that are not an empty string (no name set)
   return(dot_names[dot_names != ""])
 }
+
+#' Append an object, but retain attributes
+#'
+#' Appends values to an object, preserving its attributes. `names` are removed
+#' because they are length dependent.
+#' @inheritParams base::append x values after
+#'
+#' @returns An object with the elements of `values` appended after the specified
+#'   element of `x`.
+#'
+#' @noRd
+append_with_attrs <- function(x, values, after = length(x)){
+  attrs <- attributes(x)
+  # Names will be the wrong length when appending
+  attrs[["names"]] <- NULL
+  p_app <- base::append(unclass(x), values, after = after)
+
+  attributes(p_app) <- purrr::list_modify(
+    # Start from the newly appended attributes
+    attributes(p_app),
+    # Add our existing attributes: directory and class
+    val = !!!attrs
+  )
+  p_app
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -101,28 +101,27 @@ get_dot_names <- function(...) {
   return(dot_names[dot_names != ""])
 }
 
-#' Append an object, but retain attributes
+#' Vector merging while retaining attributes
 #'
-#' Appends values to an object, preserving its attributes. This is an extension
-#' of [base::append].
+#' Expends [base::append] but retains attributes.
 #'
-#' @inheritParams base::append x values after
-#'
-#' @returns An object with the elements of `values` appended after the specified
-#'   element of `x`.
-#'
+#' @inheritParams base::append
+#' @returns A vector containing the values in `x` with the elements of `values`
+#'   appended after the specified element of `x`, while retaining the attributes
+#'   of `x`
 #' @noRd
 append_with_attributes <- function(x, values, after = length(x)) {
-  attrs <- attributes(x)
-  # Names will be the wrong length when appending, attributes() handles this.
-  attrs[["names"]] <- NULL
+  # Keep original attributes, except names, which length will change with append
+  original_attributes <- attributes(x)
+  original_attributes[["names"]] <- NULL
 
-  # Append the object
-  p_app <- base::append(unclass(x), values, after = after)
+  # Append values (recreates names)
+  x <- base::append(unclass(x), values, after = after)
 
-  # Put attributes back into the appended object
-  for (attribute_name in names(attrs)) {
-    attr(p_app, attribute_name) <- attrs[[attribute_name]]
+  # Put original attributes back
+  for (attribute_name in names(original_attributes)) {
+    attr(x, attribute_name) <- original_attributes[[attribute_name]]
   }
-  p_app
+
+  return(x)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -110,7 +110,7 @@ append_with_attributes <- function(x, values, after = length(x)){
 
   attributes(p_app) <- purrr::list_modify(
     # Start from the newly appended attributes
-    attributes(p_app),
+    attributes(p_app) %||% list(),
     # Add our existing attributes: directory and class
     val = !!!attrs
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -101,14 +101,14 @@ get_dot_names <- function(...) {
   return(dot_names[dot_names != ""])
 }
 
-#' Vector merging while retaining attributes
+#' Vector merging while preserving attributes
 #'
-#' Expends [base::append] but retains attributes.
+#' Expends [base::append] but preserving attributes.
 #'
 #' @inheritParams base::append
 #' @returns A vector containing the values in `x` with the elements of `values`
-#'   appended after the specified element of `x`, while retaining the attributes
-#'   of `x`
+#'   appended after the specified element of `x`, while preservering the
+#'   attributes of `x`.
 #' @noRd
 append_with_attributes <- function(x, values, after = length(x)) {
   # Keep original attributes, except names, which length will change with append

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,9 +93,9 @@ get_dot_names <- function(...) {
 
 #' Append an object, but retain attributes
 #'
-#' Appends values to an object, preserving its attributes. This is an extension 
+#' Appends values to an object, preserving its attributes. This is an extension
 #' of [base::append].
-#' 
+#'
 #' @inheritParams base::append x values after
 #'
 #' @returns An object with the elements of `values` appended after the specified

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,8 +93,9 @@ get_dot_names <- function(...) {
 
 #' Append an object, but retain attributes
 #'
-#' Appends values to an object, preserving its attributes. `names` are removed
-#' because they are length dependent.
+#' Appends values to an object, preserving its attributes. This is an extension 
+#' of [base::append].
+#' 
 #' @inheritParams base::append x values after
 #'
 #' @returns An object with the elements of `values` appended after the specified
@@ -103,7 +104,7 @@ get_dot_names <- function(...) {
 #' @noRd
 append_with_attributes <- function(x, values, after = length(x)){
   attrs <- attributes(x)
-  # Names will be the wrong length when appending
+  # Names will be the wrong length when appending, attributes() handles this.
   attrs[["names"]] <- NULL
   p_app <- base::append(unclass(x), values, after = after)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -103,11 +103,11 @@ get_dot_names <- function(...) {
 
 #' Vector merging while preserving attributes
 #'
-#' Expends [base::append] but preserving attributes.
+#' Wrapper for [base::append] that preserves attributes.
 #'
 #' @inheritParams base::append
 #' @returns A vector containing the values in `x` with the elements of `values`
-#'   appended after the specified element of `x`, while preservering the
+#'   appended after the specified element of `x`, while preserving the
 #'   attributes of `x`.
 #' @noRd
 append_with_attributes <- function(x, values, after = length(x)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -101,7 +101,7 @@ get_dot_names <- function(...) {
 #'   element of `x`.
 #'
 #' @noRd
-append_with_attrs <- function(x, values, after = length(x)){
+append_with_attributes <- function(x, values, after = length(x)){
   attrs <- attributes(x)
   # Names will be the wrong length when appending
   attrs[["names"]] <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -102,17 +102,17 @@ get_dot_names <- function(...) {
 #'   element of `x`.
 #'
 #' @noRd
-append_with_attributes <- function(x, values, after = length(x)){
+append_with_attributes <- function(x, values, after = length(x)) {
   attrs <- attributes(x)
   # Names will be the wrong length when appending, attributes() handles this.
   attrs[["names"]] <- NULL
+
+  # Append the object
   p_app <- base::append(unclass(x), values, after = after)
 
-  attributes(p_app) <- purrr::list_modify(
-    # Start from the newly appended attributes
-    attributes(p_app) %||% list(),
-    # Add our existing attributes: directory and class
-    val = !!!attrs
-  )
+  # Put attributes back into the appended object
+  for (attribute_name in names(attrs)) {
+    attr(p_app, attribute_name) <- attrs[[attribute_name]]
+  }
   p_app
 }

--- a/tests/testthat/test-upgrade_descriptor.R
+++ b/tests/testthat/test-upgrade_descriptor.R
@@ -57,10 +57,9 @@ test_that("upgrade_descriptor() sets $schema to default v2 value or custom
   expect_identical(upgrade_descriptor(p_v1)$`$schema`, v2_profile)
 })
 
-test_that("upgrade_descriptor() sets $schema to the first position", {
+test_that("upgrade_resource() sets $schema as first property", {
   p_v1 <- example_package(version = "1.0")
-  p_upgraded <- upgrade_descriptor(p_v1)
-  expect_identical(names(p_upgraded)[[1]], "$schema")
+  expect_identical(names(upgrade_descriptor(p_v1))[[1]], "$schema")
 })
 
 test_that("upgrade_descriptor() updates contributor role to roles", {

--- a/tests/testthat/test-upgrade_descriptor.R
+++ b/tests/testthat/test-upgrade_descriptor.R
@@ -1,10 +1,8 @@
-# Return ----
 test_that("upgrade_descriptor() returns a valid package", {
   p_v1 <- example_package(version = "1.0")
   expect_no_error(check_package(upgrade_descriptor(p_v1)))
 })
 
-# Functionality ----
 test_that("upgrade_descriptor() upgrades a v1 package to v2", {
   p_v1 <- example_package(version = "1.0")
   expect_identical(version(upgrade_descriptor(p_v1)), "2.0")
@@ -53,6 +51,12 @@ test_that("upgrade_descriptor() sets $schema to default v2 value or custom
   # Ignore unregistered value
   p_v1$profile <- "unregistered-package"
   expect_identical(upgrade_descriptor(p_v1)$`$schema`, v2_profile)
+})
+
+test_that("upgrade_descriptor() sets $schema to the first position", {
+  p_v1 <- example_package(version = "1.0")
+  p_upgraded <- upgrade_descriptor(p_v1)
+  expect_identical(names(p_upgraded)[[1]], "$schema")
 })
 
 test_that("upgrade_descriptor() updates contributor role to roles", {

--- a/tests/testthat/test-upgrade_descriptor.R
+++ b/tests/testthat/test-upgrade_descriptor.R
@@ -1,8 +1,10 @@
+# Return ----
 test_that("upgrade_descriptor() returns a valid package", {
   p_v1 <- example_package(version = "1.0")
   expect_no_error(check_package(upgrade_descriptor(p_v1)))
 })
 
+# Functionality ----
 test_that("upgrade_descriptor() upgrades a v1 package to v2", {
   p_v1 <- example_package(version = "1.0")
   expect_identical(version(upgrade_descriptor(p_v1)), "2.0")

--- a/tests/testthat/test-upgrade_resource.R
+++ b/tests/testthat/test-upgrade_resource.R
@@ -1,4 +1,3 @@
-# Return ----
 test_that("upgrade_descriptor() returns resource object", {
   resource_v1 <- resource(example_package(version = "1.0"), "deployments")
   # Resource object has "data_location" attribute that should be kept
@@ -8,7 +7,6 @@ test_that("upgrade_descriptor() returns resource object", {
   )
 })
 
-# Functionality ----
 test_that("upgrade_resource() upgrades a v1 resource to v2", {
   resource_v1 <- resource(example_package(version = "1.0"), "deployments")
   expect_identical(version(upgrade_resource(resource_v1)), "2.0")
@@ -48,6 +46,12 @@ test_that("upgrade_resource() sets $schema to default v2 value", {
   # Ignore unregistered value
   resource_v1$profile <- "unregistered-resource"
   expect_identical(upgrade_resource(resource_v1)$`$schema`, v2_profile)
+})
+
+test_that("upgrade_resource() sets $schema to the first position", {
+  resource_v1 <- resource(example_package(version = "1.0"), "deployments")
+  resource_upgraded <- upgrade_resource(resource_v1)
+  expect_identical(names(resource_upgraded)[[1]], "$schema")
 })
 
 test_that("upgrade_resource() sets type for tabular resources", {

--- a/tests/testthat/test-upgrade_resource.R
+++ b/tests/testthat/test-upgrade_resource.R
@@ -54,10 +54,9 @@ test_that("upgrade_resource() sets $schema to default v2 value", {
   expect_identical(upgrade_resource(resource_v1)$`$schema`, v2_profile)
 })
 
-test_that("upgrade_resource() sets $schema to the first position", {
+test_that("upgrade_resource() sets $schema as first property", {
   resource_v1 <- resource(example_package(version = "1.0"), "deployments")
-  resource_upgraded <- upgrade_resource(resource_v1)
-  expect_identical(names(resource_upgraded)[[1]], "$schema")
+  expect_identical(names(upgrade_resource(resource_v1))[[1]], "$schema")
 })
 
 test_that("upgrade_resource() sets type for tabular resources", {

--- a/tests/testthat/test-upgrade_schema.R
+++ b/tests/testthat/test-upgrade_schema.R
@@ -23,6 +23,14 @@ test_that("upgrade_schema() sets $schema to default v2 value", {
     )
 })
 
+test_that("upgrade_schema() sets $schema as first property", {
+  schema_v1 <- schema(example_package(version = "1.0"), "deployments")
+  expect_identical(
+    names(upgrade_schema(resource_v1, "deployments"))[[1]],
+    "$schema"
+  )
+})
+
 test_that("upgrade_schema() updates primaryKey", {
   schema_v1 <- schema(example_package(version = "1.0"), "deployments")
 

--- a/tests/testthat/test-upgrade_schema.R
+++ b/tests/testthat/test-upgrade_schema.R
@@ -26,7 +26,7 @@ test_that("upgrade_schema() sets $schema to default v2 value", {
 test_that("upgrade_schema() sets $schema as first property", {
   schema_v1 <- schema(example_package(version = "1.0"), "deployments")
   expect_identical(
-    names(upgrade_schema(resource_v1, "deployments"))[[1]],
+    names(upgrade_schema(schema_v1, "deployments"))[[1]],
     "$schema"
   )
 })

--- a/tests/testthat/test-upgrade_schema.R
+++ b/tests/testthat/test-upgrade_schema.R
@@ -33,11 +33,11 @@ test_that("upgrade_schema() updates primaryKey", {
     list("deployment_id")
   )
 
-  # Leave undefined
+  # Undefined
   schema_v1$primaryKey <- NULL
   expect_null(upgrade_schema(schema_v1, "deployments")$primaryKey)
 
-  # Leave list
+  # List
   schema_v1$primaryKey <- list("deployment_id", "other_id")
   expect_identical(
     upgrade_schema(schema_v1, "deployments")$primaryKey,
@@ -55,11 +55,11 @@ test_that("upgrade_schema() updates foreignKeys", {
     schema(example_package(version = "2.0"), "media")$foreignKeys,
   )
 
-  # Leave undefined
+  # Undefined
   schema_v1$foreignKeys <- NULL
   expect_null(upgrade_schema(schema_v1, "media")$foreignKeys)
 
-  # Extensive example
+  # Custom properties + self-referential resource
   provided_keys <- list(
     fields = "not_in_list", # Ignore
     list(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -111,31 +111,33 @@ test_that("append_with_attributes() can handle appending nested lists", {
 })
 
 test_that("append_with_attributes() can prepend a list", {
-  attractions <- list(list(
+  lst <- list(list(
     place = "park",
     observatons = "plants"
   ))
-  expect_identical(
-    append_with_attributes(
-      attractions,
-      list(list(place = "Jurrasic World", observations = "dinosaurs")),
-      after = 0L
-    ),
-    append(
-      attractions,
-      list(list(place = "Jurrasic World", observations = "dinosaurs")),
-      after = 0L
+  lst_to_append <- list(list(
+    place = "Jurrasic World",
+    observations = "dinosaurs"
+  ))
+
+  new_place <-
+    expect_identical(
+      append_with_attributes(
+        lst,
+        lst_to_append,
+        after = 0L
+      ),
+      append(
+        lst,
+        lst_to_append,
+        after = 0L
+      )
     )
-  )
 })
 
-test_that("append_with_attributes() returns identical attributes", {
+test_that("append_with_attributes() returns identical attributes", {})
 
-})
-
-test_that("append_with_attributes() returns identical class", {
-
-})
+test_that("append_with_attributes() returns identical class", {})
 
 test_that("append_with_attributes() preserves names", {
   # Create test object

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -78,3 +78,24 @@ test_that("get_dot_names() does not return empty strings for unnamed args passed
   expect_identical(test_fn(a = "1", "2", b = "3", c = "4"), c("a", "b", "c"))
   expect_length(test_fn(a = "1", "2", b = "3", c = "4"), 3)
 })
+
+# append_with_attributes() ----
+test_that("append_with_attributes() can append a list", {
+
+})
+
+test_that("append_with_attributes() can prepend a list", {
+
+})
+
+test_that("append_with_attributes() returns identical attributes", {
+
+})
+
+test_that("append_with_attributes() returns identical class", {
+
+})
+
+test_that("append_with_attributes() does not return names", {
+
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -128,6 +128,14 @@ test_that("append_with_attributes() returns identical class", {
 
 })
 
-test_that("append_with_attributes() does not return names", {
+test_that("append_with_attributes() preserves names", {
+  # Create test object
+  lst <- head(letters, -1L)
+  # Give it some names
+  lst <- purrr::set_names(lst, toupper(lst))
 
+  expect_named(
+    append_with_attributes(lst, purrr::set_names("z", nm = "Z")),
+    toupper(letters)
+  )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -102,7 +102,22 @@ test_that("append_with_attributes() can append a list", {
 })
 
 test_that("append_with_attributes() can prepend a list", {
-
+  attractions <- list(list(
+    place = "park",
+    observatons = "plants"
+  ))
+  expect_identical(
+    append_with_attributes(
+      attractions,
+      list(list(place = "Jurrasic World", observations = "dinosaurs")),
+      after = 0L
+    ),
+    append(
+      attractions,
+      list(list(place = "Jurrasic World", observations = "dinosaurs")),
+      after = 0L
+    )
+  )
 })
 
 test_that("append_with_attributes() returns identical attributes", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -89,140 +89,77 @@ test_that("get_dot_names() does not return empty strings for unnamed args passed
 })
 
 # append_with_attributes() ----
-test_that("append_with_attributes() can append a list", {
-  lst <- list(
-    title = "Star Trek: Enterprise",
-    road = "It's a long road",
-    goal = "Getting from there to here"
-  )
-
+test_that("append_with_attributes() supports base::append() functionality", {
+  list_1 <- list(a = 1, b = 2)
+  list_2 <- list(c = 3, d = 4)
+  list_nested <- list(c = list(d = 3))
   expect_identical(
-    append_with_attributes(lst, c(frequency = "It's been a long time...")),
-    append(lst, c(frequency = "It's been a long time..."))
+    append_with_attributes(1:5, 0:1, after = 3),
+    append(1:5, 0:1, after = 3)
   )
-
   expect_identical(
-    tail(
-      append_with_attributes(lst, list(crew = list(captain = "Archer"))),
-      1L
-    ),
-    list(crew = list(captain = "Archer"))
+    append_with_attributes(list_1, list_2, after = 0),
+    append(list_1, list_2, after = 0)
+  )
+  expect_identical(
+    append_with_attributes(list_1, list_nested),
+    append(list_1, list_nested)
   )
 })
 
-test_that("append_with_attributes() can handle appending nested lists", {
-  lst <- list(a = pi)
-  lst_to_append <- list(forms = list("square", "hexagon"))
-  expect_identical(
-    append_with_attributes(lst, lst_to_append),
-    append(lst, lst_to_append)
-  )
-})
-
-test_that("append_with_attributes() can prepend a list", {
-  lst <- list(list(
-    place = "Ordovician Park",
-    observatons = "plants"
-  ))
-  lst_to_append <- list(list(
-    place = "Jurrasic Park",
-    observations = "dinosaurs"
-  ))
+test_that("append_with_attributes() preserves attributes and classes", {
+  object <- head(letters, -1L) # a, b, ... y
+  # Add custom attributes
+  attr(object, "title") <- "Letters"
+  attr(object, "description") <- "Lowercase letters in alphabetical order"
+  # Add custom class
+  class(object) <- c("letters")
+  class(object) <- c("series", class(object))
 
   expect_identical(
-    append_with_attributes(
-      lst,
-      lst_to_append,
-      after = 0L
-    ),
-    append(
-      lst,
-      lst_to_append,
-      after = 0L
-    )
+    attributes(append_with_attributes(object, "z")),
+    attributes(object)
   )
-})
-
-test_that("append_with_attributes() returns identical attributes", {
-  obj <- "a"
-  attributes(obj) <- list(species = "letter")
-
-  expect_identical(
-    attributes(append_with_attributes(obj, "b")),
-    attributes(obj)
-  )
-})
-
-test_that("append_with_attributes() returns identical class", {
-  obj <- pi
-  # single
-  class(obj) <- list("constant")
-  expect_s3_class(obj, "constant")
-  # multiple
-  class(obj) <- list(class(obj), "numeric")
   expect_s3_class(
-    obj,
-    c("constant", "numeric")
+    append_with_attributes(object, "z"),
+    c("series", "letters")
   )
 })
 
 test_that("append_with_attributes() preserves names", {
-  # Create test object
-  lst <- head(letters, -1L)
-  # Give it some names
-  lst <- purrr::set_names(lst, toupper(lst))
-
+  object <- head(letters, -1L) # a, b, ... y
+  # Add names
+  object <- purrr::set_names(object, toupper(object))
   expect_named(
-    append_with_attributes(lst, purrr::set_names("z", nm = "Z")),
+    append_with_attributes(object, c("Z" = "z")),
     toupper(letters)
   )
 })
 
-test_that("append_with_attributes() can append a Data Package resource", {
-  # Retain data_location and path
-  deployments <- example_package() |>
-    resource("deployments")
-
-  # Add a new property
-  custom_property <- list("custom_property" = "custom property value")
-  appended_resource <-
-    append_with_attributes(deployments, custom_property)
-
-  # Test attributes
-  expect_contains(
-    attributes(appended_resource),
-    list(data_location = "path")
+test_that("append_with_attributes() can return a valid package", {
+  p <- create_package()
+  p_appended <- append_with_attributes(
+    p,
+    list(custom_property = "custom_value"),
+    0
   )
-  # Test if new property was appended
-  expect_identical(
-    tail(appended_resource, 1L),
-    custom_property
-  )
+  expect_no_error(check_package(p_appended))
+  expect_identical(p_appended[[1]], "custom_value")
 })
 
-test_that("append_with_attributes() can append a Data Package", {
-  # Retain data_location and path
-  package <- example_package()
-
-  # Add a new property
-  custom_property <- list("custom_property" = "custom property value")
-  appended_package <-
-    append_with_attributes(package, custom_property)
-
-  # Test class
-  expect_s3_class(
-    appended_package,
-    "datapackage"
+test_that("append_with_attributes() can return a valid resource", {
+  resource <- resource(example_package(), "deployments")
+  resource_appended <- append_with_attributes(
+    resource,
+    list(first = "custom_value"),
+    0
   )
-
-  # Test attributes
-  expect_named(
-    appended_package,
-    c(names(package), "custom_property")
-  )
-
+  # Resource attributes are kept
   expect_identical(
-    attributes(appended_package)$directory,
-    attributes(package)$directory
+    attr(resource_appended, "data_location"),
+    attr(resource, "data_location")
   )
+  expect_identical(resource_appended[[1]], "custom_value")
 })
+
+

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -168,3 +168,25 @@ test_that("append_with_attributes() preserves names", {
     toupper(letters)
   )
 })
+
+test_that("append_with_attributes() can append a Data Package resource", {
+  # Retain data_location and path
+  deployments <- example_package() |>
+    resource("deployments")
+
+  # Add a new property
+  custom_property <- list("custom_property" = "custom property value")
+  appended_resource <-
+    append_with_attributes(deployments, custom_property)
+
+  # Test attributes
+  expect_contains(
+    attributes(appended_resource),
+    list(data_location = "path")
+  )
+  # Test if new property was appended
+  expect_identical(
+    tail(appended_resource, 1L),
+    custom_property
+  )
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -135,9 +135,28 @@ test_that("append_with_attributes() can prepend a list", {
     )
 })
 
-test_that("append_with_attributes() returns identical attributes", {})
+test_that("append_with_attributes() returns identical attributes", {
+  obj <- "a"
+  attributes(obj) <- list(species = "letter")
 
-test_that("append_with_attributes() returns identical class", {})
+  expect_identical(
+    append_with_attributes(obj, "b"),
+    attributes(obj)
+  )
+})
+
+test_that("append_with_attributes() returns identical class", {
+  obj <- pi
+  # single
+  class(obj) <- list("constant")
+  expect_s3_class(obj, "constant")
+  # multiple
+  class(obj) <- list(class(obj), "numeric")
+  expect_s3_class(
+    obj,
+    c("constant", "numeric")
+  )
+})
 
 test_that("append_with_attributes() preserves names", {
   # Create test object

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -140,7 +140,7 @@ test_that("append_with_attributes() returns identical attributes", {
   attributes(obj) <- list(species = "letter")
 
   expect_identical(
-    append_with_attributes(obj, "b"),
+    attributes(append_with_attributes(obj, "b")),
     attributes(obj)
   )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -144,14 +144,14 @@ test_that("append_with_attributes() can return a valid package", {
     0
   )
   expect_no_error(check_package(p_appended))
-  expect_identical(p_appended[[1]], "custom_value")
+  expect_identical(names(p_appended)[[1]], "custom_property")
 })
 
 test_that("append_with_attributes() can return a valid resource", {
   resource <- resource(example_package(), "deployments")
   resource_appended <- append_with_attributes(
     resource,
-    list(first = "custom_value"),
+    list(custom_property = "custom_value"),
     0
   )
   # Resource attributes are kept
@@ -159,7 +159,7 @@ test_that("append_with_attributes() can return a valid resource", {
     attr(resource_appended, "data_location"),
     attr(resource, "data_location")
   )
-  expect_identical(resource_appended[[1]], "custom_value")
+  expect_identical(names(resource_appended)[[1]], "custom_property")
 })
 
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -81,7 +81,24 @@ test_that("get_dot_names() does not return empty strings for unnamed args passed
 
 # append_with_attributes() ----
 test_that("append_with_attributes() can append a list", {
+  lst <- list(
+    title = "Star Trek: Enterprise",
+    road = "It's a long road",
+    goal = "Getting from there to here"
+  )
 
+  expect_identical(
+    append_with_attributes(lst, c(frequency = "It's been a long time...")),
+    append(lst, c(frequency = "It's been a long time..."))
+  )
+
+  expect_identical(
+    tail(
+      append_with_attributes(lst, list(crew = list(captain = "Archer"))),
+      1L
+    ),
+    list(crew = list(captain = "Archer"))
+  )
 })
 
 test_that("append_with_attributes() can prepend a list", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -190,3 +190,30 @@ test_that("append_with_attributes() can append a Data Package resource", {
     custom_property
   )
 })
+
+test_that("append_with_attributes() can append a Data Package", {
+  # Retain data_location and path
+  package <- example_package()
+
+  # Add a new property
+  custom_property <- list("custom_property" = "custom property value")
+  appended_package <-
+    append_with_attributes(package, custom_property)
+
+  # Test class
+  expect_s3_class(
+    appended_package,
+    "datapackage"
+  )
+
+  # Test attributes
+  expect_named(
+    appended_package,
+    c(names(package), "custom_property")
+  )
+
+  expect_identical(
+    attributes(appended_package)$directory,
+    attributes(package)$directory
+  )
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -101,6 +101,15 @@ test_that("append_with_attributes() can append a list", {
   )
 })
 
+test_that("append_with_attributes() can handle appending nested lists", {
+  lst <- list(a = pi)
+  lst_to_append <- list(forms = list("square", "hexagon"))
+  expect_identical(
+    append_with_attributes(lst, lst_to_append),
+    append(lst, lst_to_append)
+  )
+})
+
 test_that("append_with_attributes() can prepend a list", {
   attractions <- list(list(
     place = "park",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -112,27 +112,26 @@ test_that("append_with_attributes() can handle appending nested lists", {
 
 test_that("append_with_attributes() can prepend a list", {
   lst <- list(list(
-    place = "park",
+    place = "Ordovician Park",
     observatons = "plants"
   ))
   lst_to_append <- list(list(
-    place = "Jurrasic World",
+    place = "Jurrasic Park",
     observations = "dinosaurs"
   ))
 
-  new_place <-
-    expect_identical(
-      append_with_attributes(
-        lst,
-        lst_to_append,
-        after = 0L
-      ),
-      append(
-        lst,
-        lst_to_append,
-        after = 0L
-      )
+  expect_identical(
+    append_with_attributes(
+      lst,
+      lst_to_append,
+      after = 0L
+    ),
+    append(
+      lst,
+      lst_to_append,
+      after = 0L
     )
+  )
 })
 
 test_that("append_with_attributes() returns identical attributes", {


### PR DESCRIPTION
Fix #358

_Originally written by @PietrH in https://github.com/frictionlessdata/frictionless-r/pull/362  Edited text from original PR:_

> I ended up implementing a generic S3 method for `append()` which allowed me to set a S3 method for `append.datapackage()`. However, since `resource` objects don't have a custom class, I had to **implement a helper** to append lists while retaining attributes. Some attributes can never be kept while appending, such as names (because they depend on the length of the object staying the same, which is not the case for `append()`). Things like dimnames would also break this custom append helper, as I only added an exception for names.
> 
> Furthermore, I re-added tests for the location of the `$schema` node in `upgrade_resource()` and `upgrade_descriptor()`. Both use the same append helper code.

## TODO

- [x] Review by @peterdesmet (since he's not the original author)
- [x] Add test (any list)
- [x] Add package test (use `check_package()`
- [x] Add resource test (expect `data_location` and `path` to be retained)
- [x] Review by someone else to pass this
- [x] Rename helper to `append_with_attributes()`
- [x] See if https://github.com/frictionlessdata/frictionless-r/commit/036bb5243b9bea703f01b7a0c61995861add29b5 is reverted. => yes, but separate test to check `$schema` is first property