### PR TITLE
Update documentation to v2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ license: MIT
 title: 'frictionless: Read and Write Frictionless Data Packages'
 version: 1.3.0
 doi: 10.32614/CRAN.package.frictionless
-abstract: Read and write Frictionless Data Packages. A 'Data Package' (<https://specs.frictionlessdata.io/data-package/>)
+abstract: Read and write Frictionless Data Packages. A 'Data Package' (<https://datapackage.org/>)
   is a simple container format and standard to describe and package a collection of
   (tabular) data. It is typically used to publish FAIR (<https://www.go-fair.org/fair-principles/>)
   and open datasets.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,10 +23,9 @@ Authors@R: c(
            comment = c(ORCID = "0000-0001-7961-4280"))
   )
 Description: Read and write Frictionless Data Packages. A 'Data Package'
-    (<https://specs.frictionlessdata.io/data-package/>) is a simple
-    container format and standard to describe and package a collection of
-    (tabular) data. It is typically used to publish FAIR
-    (<https://www.go-fair.org/fair-principles/>) and open datasets.
+    (<https://datapackage.org/>) is a simple container format and standard to 
+    describe and package a collection of (tabular) data. It is typically used to
+    publish FAIR (<https://www.go-fair.org/fair-principles/>) and open datasets.
 License: MIT + file LICENSE
 URL: https://github.com/frictionlessdata/frictionless-r,
     https://docs.ropensci.org/frictionless/

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ frictionless now supports datasets specified in [v1](https://specs.frictionlessd
 - **Breaking change!** `create_package()`, `add_resource()`, `create_schema()` will create a v2 package, resource and schema respectively. Note that this can lead to mixed versions (e.g. a v1 package with a v2 resource).
 - **Breaking change!** `example_package()` now uses `version = "2.0"` as default (#360, #361).
 - `upgrade_package()` can be used to upgrade a package, its resources and verbose schemas from v1 to v2 (which gets rid of mixed versions).
+- All documentation now points to the v2 of the Data Package standard
 
 ## Data Resource changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,19 +2,19 @@
 
 frictionless now supports datasets specified in [v1](https://specs.frictionlessdata.io/) and [v2](https://datapackage.org/) of the Data Package standard. When creating a package, resource or schema, it uses the v2 specification.
 
-- All functions will return a package, resource and schema in the same version as provided.
+- All functions return a package, resource and schema in the same version as provided.
 - All functions support a v2 package, resource, dialect or schema, but might not support all v2 features.
-- **Breaking change!** `create_package()`, `add_resource()`, `create_schema()` will create a v2 package, resource and schema respectively. Note that this can lead to mixed versions (e.g. a v1 package with a v2 resource).
+- **Breaking change!** `create_package()`, `add_resource()`, `create_schema()` create a v2 package, resource and schema respectively. Note that this can lead to mixed versions (e.g. a v1 package with a v2 resource).
 - **Breaking change!** `example_package()` now uses `version = "2.0"` as default (#360, #361).
 - `upgrade_package()` can be used to upgrade a package, its resources and verbose schemas from v1 to v2 (which gets rid of mixed versions).
-- All documentation now points to the v2 of the Data Package standard
+- All documentation now points to the v2 of the Data Package standard.
 
 ## Data Resource changes
 
 * `read_resource()` and `schema()` no longer require `"profile": "tabular-data-resource"`. Nor do they require the new `"type": "table"` (which is optional in the specification). A `schema` is still expected (#343).
 - `read_resource()` now forbids reading files from a path containing a hidden directory (starting with `.`) (#359).
-* **Breaking change!** `add_resource()` sets `$schema` and `type`. It no longer sets `profile`. This means that `add_resource()` will always create a v2 resource (#343).
-* `add_resource()` now accepts any string as `resource_name`, rather than limiting to lowercase alphanumerical characters. It will trim leading and trailing spaces from the name (#344).
+* **Breaking change!** `add_resource()` sets `$schema` and `type`. It no longer sets `profile`. This means that `add_resource()` always creates a v2 resource (#343).
+* `add_resource()` now accepts any string as `resource_name`, rather than limiting to lowercase alphanumerical characters. It trims leading and trailing spaces from the name (#344).
 
 A v2 resource will look like this:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,17 +1,17 @@
 # frictionless (development version)
 
-frictionless now uses [version 2](https://datapackage.org/) of the Data Package specification.
+frictionless now supports datasets specified in [v1](https://specs.frictionlessdata.io/) and [v2](https://datapackage.org/) of the Data Package standard. When creating a package, resource or schema, it uses the v2 specification.
 
-- All functions now support a v2 package, resource, dialect or schema, but might not support all v2 features.
 - All functions will return a package, resource and schema in the same version as provided.
-- **Breaking change!** Manipulation functions `create_package()`, `add_resource()`, `create_schema()` will create a v2 package, resource and schema respectively. Note that this can lead to mixed versions (e.g. a v1 package with a v2 resource).
-- `upgrade_package()` can be used to upgrade a package, its resources and verbose schemas from v1 to v2.
-- `example_package()` now uses `version = "2.0"` as default (#360, #361).
-- `read_resource()` now forbids reading files from a path containing a hidden directory (starting with `.`) (#359).
+- All functions support a v2 package, resource, dialect or schema, but might not support all v2 features.
+- **Breaking change!** `create_package()`, `add_resource()`, `create_schema()` will create a v2 package, resource and schema respectively. Note that this can lead to mixed versions (e.g. a v1 package with a v2 resource).
+- **Breaking change!** `example_package()` now uses `version = "2.0"` as default (#360, #361).
+- `upgrade_package()` can be used to upgrade a package, its resources and verbose schemas from v1 to v2 (which gets rid of mixed versions).
 
 ## Data Resource changes
 
 * `read_resource()` and `schema()` no longer require `"profile": "tabular-data-resource"`. Nor do they require the new `"type": "table"` (which is optional in the specification). A `schema` is still expected (#343).
+- `read_resource()` now forbids reading files from a path containing a hidden directory (starting with `.`) (#359).
 * **Breaking change!** `add_resource()` sets `$schema` and `type`. It no longer sets `profile`. This means that `add_resource()` will always create a v2 resource (#343).
 * `add_resource()` now accepts any string as `resource_name`, rather than limiting to lowercase alphanumerical characters. It will trim leading and trailing spaces from the name (#344).
 

--- a/R/check_path.R
+++ b/R/check_path.R
@@ -1,7 +1,7 @@
 #' Check a path or URL
 #'
 #' Check if a [path or URL](
-#' https://specs.frictionlessdata.io/data-resource/#url-or-path) is valid (and
+#' https://datapackage.org/standard/data-resource/#path-or-data) is valid (and
 #' optionally safe) and prepend with directory to create an absolute path or
 #' URL.
 #' Returns error when no file can be found.

--- a/R/example_package.R
+++ b/R/example_package.R
@@ -10,9 +10,10 @@
 #' 3. `media`: inline data stored in `data`.
 #'
 #' The example Data Package is available in two versions:
-#' - `1.0`: specified as a [Data Package v1](
-#'   https://specs.frictionlessdata.io/).
-#' - `2.0`: specified as a [Data Package v2](https://datapackage.org/).
+#' - `1.0`: specified in [v1](https://specs.frictionlessdata.io/) of the Data
+#'   Package standard.
+#' - `2.0`: specified in [v2](https://datapackage.org/) of the Data Package
+#'   standard.
 #'
 #' @param version Data Package standard version.
 #' @returns A Data Package object, see [create_package()].

--- a/R/read_package.R
+++ b/R/read_package.R
@@ -1,7 +1,7 @@
 #' Read a Data Package descriptor file (`datapackage.json`)
 #'
 #' Reads information from a `datapackage.json` file, i.e. the [descriptor](
-#' https://specs.frictionlessdata.io/data-package/#descriptor) file that
+#' https://datapackage.org/standard/data-package/#descriptor) file that
 #' describes the Data Package metadata and its Data Resources.
 #'
 #' See `vignette("data-package")` to learn how this function implements the

--- a/R/resource.R
+++ b/R/resource.R
@@ -62,7 +62,7 @@ resource <- function(package, resource_name) {
   resource <- purrr::keep(package$resources, ~ .x$name == resource_name)[[1]]
 
   # Check that path or data are set
-  # https://specs.frictionlessdata.io/data-resource/#data-location
+  # https://datapackage.org/standard/data-resource/#path-or-data
   if (is.null(resource$path) && is.null(resource$data)) {
     cli::cli_abort(
       "Resource {.val {resource_name}} must have a {.field path} or

--- a/README.Rmd
+++ b/README.Rmd
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5815355.svg)](https://doi.org/10.5281/zenodo.5815355)
 <!-- badges: end -->
 
-frictionless is an R package to read and write Frictionless Data Packages. A [Data Package](https://specs.frictionlessdata.io/data-package/) is a simple container format and standard to describe and package a collection of (tabular) data. It is typically used to publish [FAIR](https://www.go-fair.org/fair-principles/) and open datasets.
+frictionless is an R package to read and write Frictionless Data Packages. A [Data Package](https://datapackage.org/) is a simple container format and standard to describe and package a collection of (tabular) data. It is typically used to publish [FAIR](https://www.go-fair.org/fair-principles/) and open datasets.
 
 To get started, see:
 
@@ -33,7 +33,7 @@ To get started, see:
 - [Function reference](https://docs.ropensci.org/frictionless/reference/index.html): overview of all functions.
 - [Standard implementation](https://docs.ropensci.org/frictionless/articles/index.html): how frictionless implements the Data Package standard.
 
-**frictionless currently implements [Data Package v1](https://specs.frictionlessdata.io/).** Our goal is to support [Data Package v2](https://datapackage.org/) as well.
+frictionless supports datasets specified in [v1](https://specs.frictionlessdata.io/) and [v2](https://datapackage.org/) of the Data Package standard. When creating a package, resource or schema, it uses the v2 specification.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ status](https://www.repostatus.org/badges/latest/active.svg)](https://www.repost
 <!-- badges: end -->
 
 frictionless is an R package to read and write Frictionless Data
-Packages. A [Data
-Package](https://specs.frictionlessdata.io/data-package/) is a simple
+Packages. A [Data Package](https://datapackage.org/) is a simple
 container format and standard to describe and package a collection of
 (tabular) data. It is typically used to publish
 [FAIR](https://www.go-fair.org/fair-principles/) and open datasets.
@@ -36,9 +35,10 @@ To get started, see:
   implementation](https://docs.ropensci.org/frictionless/articles/index.html):
   how frictionless implements the Data Package standard.
 
-**frictionless currently implements [Data Package
-v1](https://specs.frictionlessdata.io/).** Our goal is to support [Data
-Package v2](https://datapackage.org/) as well.
+frictionless supports datasets specified in
+[v1](https://specs.frictionlessdata.io/) and
+[v2](https://datapackage.org/) of the Data Package standard. When
+creating a package, resource or schema, it uses the v2 specification.
 
 ## Installation
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -2,7 +2,7 @@
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
   "@type": "SoftwareSourceCode",
   "identifier": "frictionless",
-  "description": "Read and write Frictionless Data Packages. A 'Data Package' (<https://specs.frictionlessdata.io/data-package/>) is a simple container format and standard to describe and package a collection of (tabular) data. It is typically used to publish FAIR (<https://www.go-fair.org/fair-principles/>) and open datasets.",
+  "description": "Read and write Frictionless Data Packages. A 'Data Package' (<https://datapackage.org/>) is a simple container format and standard to describe and package a collection of (tabular) data. It is typically used to publish FAIR (<https://www.go-fair.org/fair-principles/>) and open datasets.",
   "name": "frictionless: Read and Write Frictionless Data Packages",
   "relatedLink": ["https://docs.ropensci.org/frictionless/", "https://CRAN.R-project.org/package=frictionless"],
   "codeRepository": "https://github.com/frictionlessdata/frictionless-r",

--- a/man/example_package.Rd
+++ b/man/example_package.Rd
@@ -27,8 +27,10 @@ camera trap data organized in 3 Data Resources:
 \details{
 The example Data Package is available in two versions:
 \itemize{
-\item \code{1.0}: specified as a \href{https://specs.frictionlessdata.io/}{Data Package v1}.
-\item \code{2.0}: specified as a \href{https://datapackage.org/}{Data Package v2}.
+\item \code{1.0}: specified in \href{https://specs.frictionlessdata.io/}{v1} of the Data
+Package standard.
+\item \code{2.0}: specified in \href{https://datapackage.org/}{v2} of the Data Package
+standard.
 }
 }
 \examples{

--- a/man/frictionless-package.Rd
+++ b/man/frictionless-package.Rd
@@ -6,7 +6,7 @@
 \alias{frictionless-package}
 \title{frictionless: Read and Write Frictionless Data Packages}
 \description{
-Read and write Frictionless Data Packages. A 'Data Package' (\url{https://specs.frictionlessdata.io/data-package/}) is a simple container format and standard to describe and package a collection of (tabular) data. It is typically used to publish FAIR (\url{https://www.go-fair.org/fair-principles/}) and open datasets.
+Read and write Frictionless Data Packages. A 'Data Package' (\url{https://datapackage.org/}) is a simple container format and standard to describe and package a collection of (tabular) data. It is typically used to publish FAIR (\url{https://www.go-fair.org/fair-principles/}) and open datasets.
 }
 \seealso{
 Useful links:

--- a/man/read_package.Rd
+++ b/man/read_package.Rd
@@ -13,7 +13,7 @@ read_package(file = "datapackage.json")
 A Data Package object, see \code{\link[=create_package]{create_package()}}.
 }
 \description{
-Reads information from a \code{datapackage.json} file, i.e. the \href{https://specs.frictionlessdata.io/data-package/#descriptor}{descriptor} file that
+Reads information from a \code{datapackage.json} file, i.e. the \href{https://datapackage.org/standard/data-package/#descriptor}{descriptor} file that
 describes the Data Package metadata and its Data Resources.
 }
 \details{

--- a/package.json
+++ b/package.json
@@ -1,1 +1,0 @@
-{"contributors":[{"title":["Peter"],"roles":[["author"]]}]}

--- a/tests/testthat/test-add_resource.R
+++ b/tests/testthat/test-add_resource.R
@@ -460,8 +460,10 @@ test_that("add_resource() always creates a v2 resource", {
   p_v2 <- example_package(version = "2.0")
   df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
   p_v1 <- add_resource(p_v1, "new", df)
+  p_v1_replaced <- add_resource(p_v1, "deployments", df, replace = TRUE)
   p_v2 <- add_resource(p_v2, "new", df)
   expect_identical(version(resource(p_v1, "new")), "2.0")
+  expect_identical(version(resource(p_v1_replaced, "deployments")), "2.0")
   expect_identical(version(resource(p_v2, "new")), "2.0")
 
   # See further for setting $schema

--- a/tests/testthat/test-upgrade_descriptor.R
+++ b/tests/testthat/test-upgrade_descriptor.R
@@ -15,10 +15,14 @@ test_that("upgrade_descriptor() leaves a v2 package as is", {
   expect_identical(upgrade_descriptor(p_v2), p_v2)
 })
 
-test_that("upgrade_descriptor() removes profile", {
+test_that("upgrade_descriptor() removes profile, unless $schema is set", {
   p_v1 <- example_package(version = "1.0")
   p_v1$profile <- "data-package"
   expect_null(upgrade_descriptor(p_v1)$profile)
+
+  p_v2 <- example_package(version = "2.0")
+  p_v2$profile <- "data-package"
+  expect_identical(upgrade_descriptor(p_v2)$profile, "data-package") # Kept
 })
 
 test_that("upgrade_descriptor() sets $schema to default v2 value or custom

--- a/tests/testthat/test-upgrade_resource.R
+++ b/tests/testthat/test-upgrade_resource.R
@@ -19,10 +19,14 @@ test_that("upgrade_resource() leaves a v2 resource as is", {
   expect_identical(upgrade_resource(resource_v2), resource_v2)
 })
 
-test_that("upgrade_resource() removes profile", {
+test_that("upgrade_resource() removes profile, unless $schema is set", {
   resource_v1 <- resource(example_package(version = "1.0"), "deployments")
   resource_v1$profile <- "data-resource"
   expect_null(upgrade_resource(resource_v1)$profile)
+
+  resource_v2 <- resource(example_package(version = "2.0"), "deployments")
+  resource_v2$profile <- "data-resource"
+  expect_identical(upgrade_descriptor(resource_v2)$profile, "data-resource") # Kept
 })
 
 test_that("upgrade_resource() sets $schema to default v2 value", {

--- a/tests/testthat/test-version.R
+++ b/tests/testthat/test-version.R
@@ -24,7 +24,7 @@ test_that("version() returns correct version for package", {
   expect_identical(version(package), "3.0")
 
   # Custom extensions
-  package$`$schema` <- "https://custom.datapackage.org/package-profile.json"
+  package$`$schema` <- "https://custom.datapackage.org/1.0/package-profile.json"
   expect_identical(version(package), ">=2.0")
   package$`$schema` <- "https://rs.tdwg.org/dwc-dp/1.0/dwc-dp-profile.json"
   expect_identical(version(package), ">=2.0")
@@ -58,7 +58,7 @@ test_that("version() returns correct version for resource", {
   expect_identical(version(resource), "3.0")
 
   # Custom extensions
-  resource$`$schema` <- "https://custom.datapackage.org/resource-profile.json"
+  resource$`$schema` <- "https://custom.datapackage.org/1.0/resource-profile.json"
   expect_identical(version(resource), ">=2.0")
 })
 
@@ -92,7 +92,7 @@ test_that("version() returns correct version for dialect", {
   expect_identical(version(dialect), "3.0")
 
   # Custom extensions
-  dialect$`$schema` <- "https://custom.datapackage.org/dialect-profile.json"
+  dialect$`$schema` <- "https://custom.datapackage.org/1.0/dialect-profile.json"
   expect_identical(version(dialect), ">=2.0")
 })
 
@@ -123,7 +123,7 @@ test_that("version() returns correct version for schema", {
   expect_identical(version(schema), "3.0")
 
   # Custom extensions
-  schema$`$schema` <- "https://custom.datapackage.org/schema-profile.json"
+  schema$`$schema` <- "https://custom.datapackage.org/1.0/schema-profile.json"
   expect_identical(version(schema), ">=2.0")
 })
 

--- a/tests/testthat/test-version.R
+++ b/tests/testthat/test-version.R
@@ -127,7 +127,7 @@ test_that("version() returns correct version for schema", {
   expect_identical(version(schema), ">=2.0")
 })
 
-## Example package ----
+## Functionality ----
 test_that("version() returns correct version for example package properties", {
   p_v1 <- example_package(version = "1.0")
 
@@ -156,7 +156,13 @@ test_that("version() returns correct version for example package properties", {
   expect_identical(version(resource(p_v2, "deployments")$schema), "2.0")
 })
 
-## Invalid ----
+test_that("version() returns ignores profile if $schema is defined", {
+  x <- list()
+  x$profile <- "data-package" # v1
+  x$`$schema` <- "https://datapackage.org/profiles/2.0/datapackage.json" # v2
+  expect_identical(version(x), "2.0")
+})
+
 test_that("version() returns >=2.0 for invalid $schema", {
   x <- list()
   x$`$schema` <- list()

--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -139,7 +139,7 @@ package
 
 ### version
 
-[`version`](https://datapackage.org/standard/data-package/#created) is ignored by `read_package()` and not set by `create_package()`.
+[`version`](https://datapackage.org/standard/data-package/#version) is ignored by `read_package()` and not set by `create_package()`.
 
 ### created
 

--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -97,7 +97,7 @@ my_package
 
 ### profile
 
-[`profile`](https://specs.frictionlessdata.io/data-package/#profile) (a deprecated v1 property) is ignored by `read_package()` and not set by `create_package()`. `upgrade_package()` removes `profile`, but retains its value in `$schema` if it is a URL to a custom profile.
+[`profile`](https://specs.frictionlessdata.io/data-package/#profile) (a deprecated v1 property) is ignored by `read_package()` and not set by `create_package()`. `upgrade_package()` removes `profile` (unless `$schema` is already set), but retains its value in `$schema` if it is a URL to a custom profile.
 
 ### resources
 

--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -93,15 +93,15 @@ my_package
 
 ### $schema
 
-[`$schema`](https://datapackage.org/standard/data-package/#dollar-schema) indicates what version of the Data Package standard is used (v1 if undefined). It is ignored by `read_package()`. `create_package()` sets `$schema` to `"https://datapackage.org/profiles/2.0/datapackage.json"` (the recommended v2 value).
+[`$schema`](https://datapackage.org/standard/data-package/#dollar-schema) indicates what version of the Data Package standard is used (v1 if undefined). It is ignored by `read_package()`. `create_package()` sets `$schema` to `"https://datapackage.org/profiles/2.0/datapackage.json"` (the recommended v2 value). `upgrade_package()` does the same, except for certain `profile` values.
+
+### profile
+
+[`profile`](https://specs.frictionlessdata.io/data-package/#profile) (a deprecated v1 property) is ignored by `read_package()` and not set by `create_package()`. `upgrade_package()` removes `profile`, but retains its value in `$schema` if it is a URL to a custom profile.
 
 ### resources
 
 [`resources`](https://datapackage.org/standard/data-package/#resources) is required. It is used by `resource_names()` and many other functions. `check_package()` returns an error if it is missing.
-
-### profile
-
-[`profile`](https://specs.frictionlessdata.io/data-package/#profile) (a deprecated v1 property) is ignored by `read_package()` and not set by `create_package()`. `upgrade_package()` will remove `profile`, but retain its value in `$schema` if it is a URL to a custom profile.
 
 ### name
 
@@ -143,7 +143,7 @@ package
 
 ### created
 
-[`created`](https://specs.frictionlessdata.io/data-package/#created) is ignored by `read_package()` and not set by `create_package()`.
+[`created`](https://datapackage.org/standard/data-package/#created) is ignored by `read_package()` and not set by `create_package()`.
 
 ### keywords
 
@@ -151,7 +151,7 @@ package
 
 ### contributors
 
-[`contributors`](https://datapackage.org/standard/data-package/#contributors) is ignored by `read_package()` and not set by `create_package()`. `upgrade_package()` will convert `"role": "value"` to `"roles": ["value"]`.
+[`contributors`](https://datapackage.org/standard/data-package/#contributors) is ignored by `read_package()` and not set by `create_package()`. `upgrade_package()` converts `"role": "value"` to `"roles": ["value"]` for all contributors.
 
 ### sources
 

--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -97,7 +97,7 @@ my_package
 
 ### profile
 
-[`profile`](https://specs.frictionlessdata.io/data-package/#profile) (a deprecated v1 property) is ignored by `read_package()` and not set by `create_package()`. `upgrade_package()` removes `profile` (unless `$schema` is already set), but retains its value in `$schema` if it is a URL to a custom profile.
+[`profile`](https://specs.frictionlessdata.io/data-package/#profile) (a deprecated v1 property) is ignored by `read_package()` and not set by `create_package()`. `upgrade_package()` removes `profile` (unless `$schema` is already set), but retains its value in `$schema` if it is a URL to a custom profile (for [backwards compatibility](https://datapackage.org/standard/data-package/#dollar-schema)).
 
 ### resources
 
@@ -151,7 +151,7 @@ package
 
 ### contributors
 
-[`contributors`](https://datapackage.org/standard/data-package/#contributors) is ignored by `read_package()` and not set by `create_package()`. `upgrade_package()` converts `"role": "value"` to `"roles": ["value"]` for all contributors.
+[`contributors`](https://datapackage.org/standard/data-package/#contributors) is ignored by `read_package()` and not set by `create_package()`. `upgrade_package()` converts `"role": "value"` to `"roles": ["value"]` for all contributors (for [backwards compatibility](https://datapackage.org/overview/changelog/#packagecontributors-updated)).
 
 ### sources
 

--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -49,7 +49,7 @@ A package is a list, with all the properties that were present in the `datapacka
 attributes(package)
 ```
 
-`create_package()` creates a package from scratch or from an existing package. **It will always create a package following the [v2 specification](https://datapackage.org/standard/data-package/).** It adds the required properties, attribute and class if those are missing:
+`create_package()` creates a package from scratch or from an existing package. **It always creates a package following the [v2 specification](https://datapackage.org/standard/data-package/).** It adds the required properties, attribute and class if those are missing:
 
 ```{r}
 # From scratch

--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -49,7 +49,7 @@ A package is a list, with all the properties that were present in the `datapacka
 attributes(package)
 ```
 
-`create_package()` creates a package from scratch or from an existing package. It adds the required properties, attribute and class if those are missing:
+`create_package()` creates a package from scratch or from an existing package. **It will always create a package following the [v2 specification](https://datapackage.org/standard/data-package/).** It adds the required properties, attribute and class if those are missing:
 
 ```{r}
 # From scratch
@@ -93,7 +93,7 @@ my_package
 
 ### $schema
 
-[`$schema`](https://datapackage.org/standard/data-package/#dollar-schema) indicates what version of the Data Package standard is used (v1 if undefined). It is ignored by `read_package()`. `create_package()` sets `$schema` to `"https://datapackage.org/profiles/2.0/datapackage.json"` (the recommended v2 value). `upgrade_package()` does the same, except for certain `profile` values.
+[`$schema`](https://datapackage.org/standard/data-package/#dollar-schema) indicates what version of the Data Package standard is used (v1 if undefined). It is ignored by `read_package()`. `create_package()` sets `$schema` to `"https://datapackage.org/profiles/2.0/datapackage.json"` (the recommended v2 value) and thus creates a v2 package. `upgrade_package()` does the same, except for certain `profile` values.
 
 ### profile
 

--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -93,7 +93,11 @@ my_package
 
 ### $schema
 
-[`$schema`](https://datapackage.org/standard/data-package/#dollar-schema) indicates what version of the Data Package standard is used (v1 if undefined). It is ignored by `read_package()`. `create_package()` sets `$schema` to `"https://datapackage.org/profiles/2.0/datapackage.json"` (the recommended v2 value) and thus creates a v2 package. `upgrade_package()` does the same, except for certain `profile` values.
+[`$schema`](https://datapackage.org/standard/data-package/#dollar-schema) indicates what `version()` of the Data Package standard is used (v1 if undefined).
+
+- `read_package()` ignores it, since all package properties supported by frictionless are the same in v1 and v2.
+- `create_package()` sets `$schema` to the recommended v2 value (`"https://datapackage.org/profiles/2.0/datapackage.json"`) and thus creates a v2 package.
+- `upgrade_package()` sets `$schema` to the recommended v2 value, except for certain `profile` values.
 
 ### profile
 

--- a/vignettes/data-package.Rmd
+++ b/vignettes/data-package.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-[Data Package](https://specs.frictionlessdata.io/data-package/) is a simple container format to describe a coherent collection of data (a dataset), including its contributors, licenses, etc.
+[Data Package](https://datapackage.org/standard/data-package/) is a simple container format to describe a coherent collection of data (a dataset), including its contributors, licenses, etc.
 
 ::: {.callout-note}
 In this document we use the terms "package" for Data Package, "resource" for Data Resource, "dialect" for Table Dialect, and "schema" for Table Schema.
@@ -31,7 +31,7 @@ frictionless supports reading, manipulating and writing packages. Much of its fu
 
 ```{r}
 library(frictionless)
-file <- system.file("extdata", "v1", "datapackage.json", package = "frictionless")
+file <- system.file("extdata", "v2", "datapackage.json", package = "frictionless")
 package <- read_package(file)
 ```
 
@@ -43,13 +43,13 @@ package
 
 ### Manipulate
 
-A package is a list, with all the properties that were present in the `datapackage.json` file (e.g. `name`, `id`, etc.). frictionless adds the custom property `"directory"` to support reading data (which is removed when writing to disk) and extends the class with `"datapackage"` to support printing and checking:
+A package is a list, with all the properties that were present in the `datapackage.json` file (e.g. `name`, `id`, etc.). frictionless adds the custom attribute `"directory"` to support reading data (which is removed when writing to disk) and extends the class with `"datapackage"` to support printing and checking:
 
 ```{r}
 attributes(package)
 ```
 
-`create_package()` creates a package from scratch or from an existing package. It adds the required properties and class if those are missing:
+`create_package()` creates a package from scratch or from an existing package. It adds the required properties, attribute and class if those are missing:
 
 ```{r}
 # From scratch
@@ -91,23 +91,25 @@ my_package
 
 ## Properties implementation
 
+### $schema
+
+[`$schema`](https://datapackage.org/standard/data-package/#dollar-schema) indicates what version of the Data Package standard is used (v1 if undefined). It is ignored by `read_package()`. `create_package()` sets `$schema` to `"https://datapackage.org/profiles/2.0/datapackage.json"` (the recommended v2 value).
+
 ### resources
 
-[`resources`](https://specs.frictionlessdata.io/data-package/#resource-information) is required. It is used by `resource_names()` and many other functions. `check_package()` returns an error if it is missing.
-
-<!-- ### $schema -->
+[`resources`](https://datapackage.org/standard/data-package/#resources) is required. It is used by `resource_names()` and many other functions. `check_package()` returns an error if it is missing.
 
 ### profile
 
-[`profile`](https://specs.frictionlessdata.io/data-package/#profile) is ignored by `read_package()` and not set (to e.g. `"tabular-data-package"`) by `create_package()`.
+[`profile`](https://specs.frictionlessdata.io/data-package/#profile) (a deprecated v1 property) is ignored by `read_package()` and not set by `create_package()`. `upgrade_package()` will remove `profile`, but retain its value in `$schema` if it is a URL to a custom profile.
 
 ### name
 
-[`name`](https://specs.frictionlessdata.io/data-package/#name) is ignored by `read_package()` and not set by `create_package()`.
+[`name`](https://datapackage.org/standard/data-package/#name) is ignored by `read_package()` and not set by `create_package()`.
 
 ### id
 
-[`id`](https://specs.frictionlessdata.io/data-package/#id) is ignored by `read_package()` and not set by `create_package()`. `print.datapackage()` adds an extra sentence when `id` is a URL (like a DOI):
+[`id`](https://datapackage.org/standard/data-package/#id) is ignored by `read_package()` and not set by `create_package()`. `print.datapackage()` adds an extra sentence when `id` is a URL (like a DOI):
 
 ```{r}
 package <- example_package()
@@ -117,27 +119,27 @@ package
 
 ### licenses
 
-[`licenses`](https://specs.frictionlessdata.io/data-package/#licenses) is ignored by `read_package()` and not set by `create_package()`.
+[`licenses`](https://datapackage.org/standard/data-package/#licenses) is ignored by `read_package()` and not set by `create_package()`.
 
 ### title
 
-[`title`](https://specs.frictionlessdata.io/data-package/#title) is ignored by `read_package()` and not set by `create_package()`.
+[`title`](https://datapackage.org/standard/data-package/#title) is ignored by `read_package()` and not set by `create_package()`.
 
 ### description
 
-[`description`](https://specs.frictionlessdata.io/data-package/#description) is ignored by `read_package()` and not set by `create_package()`.
+[`description`](https://datapackage.org/standard/data-package/#description) is ignored by `read_package()` and not set by `create_package()`.
 
 ### homepage
 
-[`homepage`](https://specs.frictionlessdata.io/data-package/#homepage) is ignored by `read_package()` and not set by `create_package()`.
+[`homepage`](https://datapackage.org/standard/data-package/#homepage) is ignored by `read_package()` and not set by `create_package()`.
 
 ### image
 
-[`image`](https://specs.frictionlessdata.io/data-package/#image) is ignored by `read_package()` and not set by `create_package()`.
+[`image`](https://datapackage.org/standard/data-package/#image) is ignored by `read_package()` and not set by `create_package()`.
 
 ### version
 
-[`version`](https://specs.frictionlessdata.io/data-package/#version) is ignored by `read_package()` and not set by `create_package()`.
+[`version`](https://datapackage.org/standard/data-package/#created) is ignored by `read_package()` and not set by `create_package()`.
 
 ### created
 
@@ -145,12 +147,12 @@ package
 
 ### keywords
 
-[`keywords`](https://specs.frictionlessdata.io/data-package/#keywords) is ignored by `read_package()` and not set by `create_package()`.
+[`keywords`](https://datapackage.org/standard/data-package/#keywords) is ignored by `read_package()` and not set by `create_package()`.
 
 ### contributors
 
-[`contributors`](https://specs.frictionlessdata.io/data-package/#contributors) is ignored by `read_package()` and not set by `create_package()`.
+[`contributors`](https://datapackage.org/standard/data-package/#contributors) is ignored by `read_package()` and not set by `create_package()`. `upgrade_package()` will convert `"role": "value"` to `"roles": ["value"]`.
 
 ### sources
 
-[`sources`](https://specs.frictionlessdata.io/data-package/#sources) is ignored by `read_package()` and not set by `create_package()`.
+[`sources`](https://datapackage.org/standard/data-package/#sources) is ignored by `read_package()` and not set by `create_package()`.

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -99,7 +99,11 @@ You can pipe most functions (see `vignette("data-package")`).
 
 ### $schema
 
-[`$schema`](https://datapackage.org/standard/data-resource/#dollar-schema) indicates what version of the Data Resource standard is used (v1 if undefined). It is used by `read_resource()` to determine the version and **silently upgrade the resource from v1 to v2** before trying to read it. `add_resource()` sets `$schema` to `"https://datapackage.org/profiles/2.0/dataresource.json"` (the recommended v2 value) and thus creates a v2 resource. `upgrade_package()` does the same for all resources of a package.
+[`$schema`](https://datapackage.org/standard/data-resource/#dollar-schema) indicates what `version()` of the Data Resource standard is used (v1 if undefined).
+
+- `read_resource()` uses it to detect if a resource is v1 and silently upgrade it to v2 before trying to read it.
+- `add_resource()` sets `$schema` to the recommended v2 value (`"https://datapackage.org/profiles/2.0/dataresource.json"`) and thus creates a v2 resource.
+- `upgrade_package()` set `$schema` to the recommended v2 value for all resources of a package.
 
 ### profile
 

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -103,7 +103,7 @@ You can pipe most functions (see `vignette("data-package")`).
 
 ### profile
 
-[`profile`](https://specs.frictionlessdata.io/data-resource/#profile) (a deprecated v1 property) is ignored by `read_resource()` and not set by `add_resource()`. `upgrade_package()` removes `profile`  (unless `$schema` is already set), but converts `"profile" = "tabular-data-resource"` to `"type" = "table"`.
+[`profile`](https://specs.frictionlessdata.io/data-resource/#profile) (a deprecated v1 property) is ignored by `read_resource()` and not set by `add_resource()`. `upgrade_package()` removes `profile`  (unless `$schema` is already set), but converts `"profile" = "tabular-data-resource"` to `"type" = "table"` (for [backwards compatibility](https://datapackage.org/standard/data-resource/#type)).
 
 ### name
 
@@ -144,7 +144,7 @@ add_resource(package, "deployments", data = path, replace = TRUE)
 ### data
 
 ::: {.callout-warning}
-Support for inline `data` is currently limited, e.g. JSON object and string are not supported and `schema`, `mediatype` and `format` are ignored.
+Support for inline `data` is currently limited, e.g. JSON object and string are **not supported** and `schema`, `mediatype` and `format` are ignored.
 :::
 
 `data` is for inline data (included in the `datapackage.json`). `read_resource()` attempts to read `data` if it is provided as a JSON array:

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -129,7 +129,7 @@ When multiple paths are provided (`"path": ["myfile1.csv", "myfile2.csv"]`), the
 
 ```{r}
 # The "observations" resource has multiple files in path
-package$resources[[2]]$path
+resource(package, "observations")$path
 # These are combined into a single data frame when reading
 read_resource(package, "observations")
 ```
@@ -151,7 +151,7 @@ Support for inline `data` is currently limited, e.g. JSON object and string are 
 
 ```{r}
 # The "media" resource has inline data
-str(package$resources[[3]]$data)
+str(resource(package, "media")$data)
 read_resource(package, "media")
 ```
 
@@ -160,7 +160,7 @@ read_resource(package, "media")
 ```{r}
 df <- data.frame("col_1" = c(1, 2), "col_2" = c("a", "b"))
 package <- add_resource(package, "df", df)
-package$resources[[4]]$data
+resource(package, "df")$data
 ```
 
 `write_package()` writes that data frame to a CSV file, adds its path to `path` and removes `data`.
@@ -182,13 +182,14 @@ package$resources[[4]]$data
 [`title`](https://datapackage.org/standard/data-resource/#title) is ignored by `read_resource()` and not set by `add_resource()`, unless provided:
 
 ```{r}
-add_resource(
+package <- add_resource(
   package,
   "iris",
   iris,
   title = "Edgar Anderson's Iris Data",
   replace = TRUE
 )
+resource(package, "iris")$title
 ```
 
 ### description
@@ -208,7 +209,7 @@ any other value | `"csv"`
 ```{r}
 path <- system.file("extdata", "v2", "observations_1.tsv", package = "frictionless")
 package <- add_resource(package, "observations", data = path, delim = "\t", replace = TRUE)
-package$resources[[2]]$format
+resource(package, "observations")$format
 ```
 
 `add_resource()` leaves `format` undefined when data are provided as a data frame. `write_package()` sets it to `"csv"` when writing to disk.
@@ -226,7 +227,7 @@ any other value | `"text/csv"`
 ```{r}
 path <- system.file("extdata", "v2", "observations_1.tsv", package = "frictionless")
 package <- add_resource(package, "observations", data = path, delim = "\t", replace = TRUE)
-package$resources[[2]]$mediatype
+resource(package, "observations")$mediatype
 ```
 
 `add_resource()` leaves `mediatype` undefined when data are provided as a data frame. `write_package()` sets it to `"text/csv"` when writing to disk.
@@ -240,7 +241,7 @@ package$resources[[2]]$mediatype
 ```{r}
 path <- system.file("extdata", "v2", "deployments.csv", package = "frictionless")
 package <- add_resource(package, "deployments", data = path, delim = ",", replace = TRUE)
-package$resources[[2]]$encoding
+resource(package, "observations")$encoding
 ```
 
 ### bytes

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-[Data Resource](https://specs.frictionlessdata.io/data-resource/) is a simple format to describe a data resource such as an individual table or file, including its name, format, path, etc.
+[Data Resource](https://datapackage.org/standard/data-resource/) is a simple format to describe a data resource such as an individual table or file, including its name, format, path, etc.
 
 ::: {.callout-note}
 In this document we use the terms "package" for Data Package, "resource" for Data Resource, "dialect" for Table Dialect, and "schema" for Table Schema.
@@ -83,7 +83,7 @@ remove_resource(package, "deployments")
 add_resource(package, "iris", data = iris)
 
 # Replace a resource with one where data is stored in a tabular file
-path <- system.file("extdata", "v1", "deployments.csv", package = "frictionless")
+path <- system.file("extdata", "v2", "deployments.csv", package = "frictionless")
 add_resource(package, "deployments", data = path, replace = TRUE)
 ```
 
@@ -99,11 +99,15 @@ You can pipe most functions (see `vignette("data-package")`).
 
 ### $schema
 
-[`$schema`](https://datapackage.org/standard/data-resource/#dollar-schema) indicates what version of the Data Resource standard is used (v1 if undefined). It is ignored by `read_resource()`. `add_resource()` sets `$schema` to `"https://datapackage.org/profiles/2.0/dataresource.json"` (the recommended v2 value).
+[`$schema`](https://datapackage.org/standard/data-resource/#dollar-schema) indicates what version of the Data Resource standard is used (v1 if undefined). It is ignored by `read_resource()`. `add_resource()` sets `$schema` to `"https://datapackage.org/profiles/2.0/dataresource.json"` (the recommended v2 value). `upgrade_package()` does the same for all resources of a package.
+
+### profile
+
+[`profile`](https://specs.frictionlessdata.io/data-resource/#profile) (a deprecated v1 property) is ignored by `read_resource()` and not set by `add_resource()`. `upgrade_package()` removes `profile`, but converts `"profile" = "tabular-data-resource"` to `"type" = "table"`.
 
 ### name
 
-[`name`](https://specs.frictionlessdata.io/data-resource/#name) is required. It is used to identify a resource in `read_resource()`, `add_resource()` and `remove_resource()` (always as the second argument):
+[`name`](https://datapackage.org/standard/data-resource/#name) is required. It is used to identify a resource in `read_resource()`, `add_resource()` and `remove_resource()` (always as the second argument):
 
 ```{r}
 deployments <- read_resource(package, resource_name = "deployments")
@@ -117,9 +121,9 @@ add_resource(package, resource_name = "iris", data = iris)
 
 ### path
 
-[`path`](https://specs.frictionlessdata.io/data-resource/#data-location) or `data` (see further) is required. Providing both is not allowed.
+[`path`](https://datapackage.org/standard/data-resource/#path-or-data) or `data` (see further) is required. Providing both is not allowed.
 
-`path` is for data in files (e.g. a CSV file). It can be a local path or URL. Supported protocols are `http`, `https`, `ftp`, `sftp` and `sftp`. Absolute paths (`/`) or relative parent paths (`../`) are not allowed to avoid security vulnerabilities.
+`path` is for data in files (e.g. a CSV file). It can be a local path or URL. Supported protocols are `http`, `https`, `ftp`, `sftp` and `sftp`. Absolute paths (`/`), relative parent paths (`../`) and paths containing hidden directories (starting with `.`) are not allowed to avoid security vulnerabilities.
 
 When multiple paths are provided (`"path": ["myfile1.csv", "myfile2.csv"]`), the files are expected to have the same structure. `read_resource()` merges these into a single data frame in the order the paths are provided (using `dplyr::bind_rows()`):
 
@@ -133,7 +137,7 @@ read_resource(package, "observations")
 `add_resource()` sets `path` to the path(s) provided in `data`:
 
 ```{r}
-path <- system.file("extdata", "v1", "deployments.csv", package = "frictionless")
+path <- system.file("extdata", "v2", "deployments.csv", package = "frictionless")
 add_resource(package, "deployments", data = path, replace = TRUE)
 ```
 
@@ -165,21 +169,17 @@ package$resources[[4]]$data
 
 [`type`](https://datapackage.org/standard/data-resource/#type) is ignored by `read_resource()`. `add_resource()` sets `type` to `"table"` to indicate that the resource is [tabular](https://datapackage.org/standard/data-resource/#tabular).
 
-### profile
-
-[`profile`](https://specs.frictionlessdata.io/data-resource/#profile) (a deprecated v1 property) is ignored by `read_resource()` and not set by `add_resource()`. `upgrade_package()` will convert `"profile" = "tabular-data-resource"` to `"type" = "table"`.
-
 ### schema
 
-[`schema`](https://specs.frictionlessdata.io/data-resource/#resource-schemas) is required. It is used by `read_resource()` to parse data types and missing values. It can either be a JSON object or a path or URL referencing a JSON object. See `vignette("table-schema")` for details.
+[`schema`](https://datapackage.org/standard/data-resource/#schema) is required. It is used by `read_resource()` to parse data types and missing values. It can either be a JSON object or a path or URL referencing a JSON object. See `vignette("table-schema")` for details.
 
 ### dialect
 
-[`dialect`](https://specs.frictionlessdata.io/tabular-data-resource/#csv-dialect) is used by `read_resource()` to parse a tabular data file. It can either be a JSON object or a path or URL referencing a JSON object. See `vignette("table-dialect")` for details.
+[`dialect`](https://datapackage.org/standard/data-resource/#dialect) is used by `read_resource()` to parse a tabular data file. It can either be a JSON object or a path or URL referencing a JSON object. See `vignette("table-dialect")` for details.
 
 ### title
 
-[`title`](https://specs.frictionlessdata.io/data-resource/#optional-properties) is ignored by `read_resource()` and not set by `add_resource()`, unless provided:
+[`title`](https://datapackage.org/standard/data-resource/#title) is ignored by `read_resource()` and not set by `add_resource()`, unless provided:
 
 ```{r}
 add_resource(
@@ -193,11 +193,11 @@ add_resource(
 
 ### description
 
-[`description`](https://specs.frictionlessdata.io/data-resource/#optional-properties) is ignored by `read_resource()` and not set by `add_resource()` unless provided (cf. `title`).
+[`description`](https://datapackage.org/standard/data-resource/#description) is ignored by `read_resource()` and not set by `add_resource()` unless provided (cf. `title`).
 
 ### format
 
-[`format`](https://specs.frictionlessdata.io/data-resource/#optional-properties) is ignored by `read_resource()`. `add_resource()` sets `format` when data are provided as a file, based on the provided `delim`:
+[`format`](https://datapackage.org/standard/data-resource/#format) is ignored by `read_resource()`. `add_resource()` sets `format` when data are provided as a file, based on the provided `delim`:
 
 delim | format
 --- | ---
@@ -206,7 +206,7 @@ delim | format
 any other value | `"csv"`
 
 ```{r}
-path <- system.file("extdata", "v1", "observations_1.tsv", package = "frictionless")
+path <- system.file("extdata", "v2", "observations_1.tsv", package = "frictionless")
 package <- add_resource(package, "observations", data = path, delim = "\t", replace = TRUE)
 package$resources[[2]]$format
 ```
@@ -215,7 +215,7 @@ package$resources[[2]]$format
 
 ### mediatype
 
-[`mediatype`](https://specs.frictionlessdata.io/data-resource/#optional-properties) is ignored by `read_resource()`. `add_resource()` sets `mediatype` when data are provided as a file, based on the provided `delim`:
+[`mediatype`](https://datapackage.org/standard/data-resource/#mediatype) is ignored by `read_resource()`. `add_resource()` sets `mediatype` when data are provided as a file, based on the provided `delim`:
 
 delim | mediatype
 --- | ---
@@ -224,7 +224,7 @@ delim | mediatype
 any other value | `"text/csv"`
 
 ```{r}
-path <- system.file("extdata", "v1", "observations_1.tsv", package = "frictionless")
+path <- system.file("extdata", "v2", "observations_1.tsv", package = "frictionless")
 package <- add_resource(package, "observations", data = path, delim = "\t", replace = TRUE)
 package$resources[[2]]$mediatype
 ```
@@ -233,34 +233,34 @@ package$resources[[2]]$mediatype
 
 ### encoding
 
-[`encoding`](https://specs.frictionlessdata.io/data-resource/#optional-properties) (e.g. `"windows-1252"`) is used by `read_resource()` to parse the file. It defaults to UTF-8 if no `encoding` is provided or if it cannot be recognized. The returned data frame is always UTF-8.
+[`encoding`](https://datapackage.org/standard/data-resource/#encoding) (e.g. `"windows-1252"`) is used by `read_resource()` to parse the file. It defaults to UTF-8 if no `encoding` is provided or if it cannot be recognized. The returned data frame is always UTF-8.
 
 `add_resource()` guesses the `encoding` (using `readr::guess_encoding()`) when data are provided as file. It leaves the `encoding` undefined when data are provided as a data frame. `write_package()` sets it to `"utf-8"` when writing to disk.
 
 ```{r}
-path <- system.file("extdata", "v1", "deployments.csv", package = "frictionless")
+path <- system.file("extdata", "v2", "deployments.csv", package = "frictionless")
 package <- add_resource(package, "deployments", data = path, delim = ",", replace = TRUE)
 package$resources[[2]]$encoding
 ```
 
 ### bytes
 
-[`bytes`](https://specs.frictionlessdata.io/data-resource/#optional-properties) is ignored by `read_resource()` and not set by `add_resource()` unless provided (cf. `title`).
+[`bytes`](https://datapackage.org/standard/data-resource/#bytes) is ignored by `read_resource()` and not set by `add_resource()` unless provided (cf. `title`).
 
 ### hash
 
-[`hash`](https://specs.frictionlessdata.io/data-resource/#optional-properties) is ignored by `read_resource()` and not set by `add_resource()` unless provided (cf. `title`).
+[`hash`](https://datapackage.org/standard/data-resource/#hash) is ignored by `read_resource()` and not set by `add_resource()` unless provided (cf. `title`).
 
 ### sources
 
-[`sources`](https://specs.frictionlessdata.io/data-resource/#optional-properties) is ignored by `read_resource()` and not set by `add_resource()` unless provided (cf. `title`).
+[`sources`](https://datapackage.org/standard/data-resource/#sources) is ignored by `read_resource()` and not set by `add_resource()` unless provided (cf. `title`).
 
 ### licenses
 
-[`licenses`](https://specs.frictionlessdata.io/data-resource/#optional-properties) is ignored by `read_resource()` and not set by `add_resource()` unless provided (cf. `title`).
+[`licenses`](https://datapackage.org/standard/data-resource/#licenses) is ignored by `read_resource()` and not set by `add_resource()` unless provided (cf. `title`).
 
 ### compression
 
-[`compression`](https://specs.frictionlessdata.io/patterns/#specification-3) (a recipe) is ignored by `read_resource()` and not set by `add_resource()`.
+[`compression`](https://datapackage.org/recipes/compression-of-resources/) (a recipe) is ignored by `read_resource()` and not set by `add_resource()`.
 
 Compression is derived from the provided `path` instead. If the `path` ends in `.gz`, `.bz2`, `.xz`, or `.zip`, the files are automatically decompressed by `read_resource()` (using default `readr::read_delim()` functionality).

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -76,7 +76,7 @@ remove_resource(package, "deployments")
 # package <- remove_resource(package, "deployments")
 ```
 
-`add_resource()` adds or replaces a tabular resource. **It will always create a resource following the [v2 specification](https://datapackage.org/standard/data-resource/).** The provided data must be a data frame or a tabular data file (e.g. CSV):
+`add_resource()` adds or replaces a tabular resource. **It always creates a resource following the [v2 specification](https://datapackage.org/standard/data-resource/).** The provided data must be a data frame or a tabular data file (e.g. CSV):
 
 ```{r}
 # Add a resource with data from a data frame

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -76,7 +76,7 @@ remove_resource(package, "deployments")
 # package <- remove_resource(package, "deployments")
 ```
 
-`add_resource()` adds or replaces a tabular resource. The provided data must be a data frame or a tabular data file (e.g. CSV):
+`add_resource()` adds or replaces a tabular resource. **It will always create a resource following the [v2 specification](https://datapackage.org/standard/data-resource/).** The provided data must be a data frame or a tabular data file (e.g. CSV):
 
 ```{r}
 # Add a resource with data from a data frame
@@ -99,7 +99,7 @@ You can pipe most functions (see `vignette("data-package")`).
 
 ### $schema
 
-[`$schema`](https://datapackage.org/standard/data-resource/#dollar-schema) indicates what version of the Data Resource standard is used (v1 if undefined). It is used by `read_resource()` to determine the version and **silently upgrade the resource from v1 to v2** before trying to read it. `add_resource()` sets `$schema` to `"https://datapackage.org/profiles/2.0/dataresource.json"` (the recommended v2 value). `upgrade_package()` does the same for all resources of a package.
+[`$schema`](https://datapackage.org/standard/data-resource/#dollar-schema) indicates what version of the Data Resource standard is used (v1 if undefined). It is used by `read_resource()` to determine the version and **silently upgrade the resource from v1 to v2** before trying to read it. `add_resource()` sets `$schema` to `"https://datapackage.org/profiles/2.0/dataresource.json"` (the recommended v2 value) and thus creates a v2 resource. `upgrade_package()` does the same for all resources of a package.
 
 ### profile
 

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -103,7 +103,7 @@ You can pipe most functions (see `vignette("data-package")`).
 
 ### profile
 
-[`profile`](https://specs.frictionlessdata.io/data-resource/#profile) (a deprecated v1 property) is ignored by `read_resource()` and not set by `add_resource()`. `upgrade_package()` removes `profile`, but converts `"profile" = "tabular-data-resource"` to `"type" = "table"`.
+[`profile`](https://specs.frictionlessdata.io/data-resource/#profile) (a deprecated v1 property) is ignored by `read_resource()` and not set by `add_resource()`. `upgrade_package()` removes `profile`  (unless `$schema` is already set), but converts `"profile" = "tabular-data-resource"` to `"type" = "table"`.
 
 ### name
 

--- a/vignettes/data-resource.Rmd
+++ b/vignettes/data-resource.Rmd
@@ -99,7 +99,7 @@ You can pipe most functions (see `vignette("data-package")`).
 
 ### $schema
 
-[`$schema`](https://datapackage.org/standard/data-resource/#dollar-schema) indicates what version of the Data Resource standard is used (v1 if undefined). It is ignored by `read_resource()`. `add_resource()` sets `$schema` to `"https://datapackage.org/profiles/2.0/dataresource.json"` (the recommended v2 value). `upgrade_package()` does the same for all resources of a package.
+[`$schema`](https://datapackage.org/standard/data-resource/#dollar-schema) indicates what version of the Data Resource standard is used (v1 if undefined). It is used by `read_resource()` to determine the version and **silently upgrade the resource from v1 to v2** before trying to read it. `add_resource()` sets `$schema` to `"https://datapackage.org/profiles/2.0/dataresource.json"` (the recommended v2 value). `upgrade_package()` does the same for all resources of a package.
 
 ### profile
 

--- a/vignettes/frictionless.Rmd
+++ b/vignettes/frictionless.Rmd
@@ -104,39 +104,54 @@ gps
 #>  8 14256075769 TRUE    2018-05-25 16:45:55            4.25           51.3
 #>  9 14256075770 TRUE    2018-05-25 16:50:49            4.25           51.3
 #> 10 14256075771 TRUE    2018-05-25 16:55:36            4.25           51.3
+#>    `bar:barometric-pressure` `external-temperature` `gps:dop`
+#>                        <dbl>                  <dbl>     <dbl>
+#>  1                        NA                   32.5       2  
+#>  2                        NA                   32.8       2.1
+#>  3                        NA                   34.1       2.1
+#>  4                        NA                   34.5       2.2
+#>  5                        NA                   34.1       2.2
+#>  6                        NA                   32.5       2.2
+#>  7                        NA                   32.1       2.2
+#>  8                        NA                   33.3       2.1
+#>  9                        NA                   32.6       2.1
+#> 10                        NA                   31.7       2  
 #> # ℹ 73,037 more rows
-#> # ℹ 16 more variables: `bar:barometric-pressure` <dbl>,
-#> #   `external-temperature` <dbl>, `gps:dop` <dbl>, `gps:satellite-count` <dbl>,
-#> #   `gps-time-to-fix` <dbl>, `ground-speed` <dbl>, heading <dbl>,
-#> #   `height-above-msl` <dbl>, `location-error-numerical` <dbl>,
-#> #   `manually-marked-outlier` <lgl>, `vertical-error-numerical` <dbl>,
-#> #   `sensor-type` <chr>, `individual-taxon-canonical-name` <chr>, …
+#> # ℹ 13 more variables: `gps:satellite-count` <dbl>, `gps-time-to-fix` <dbl>,
+#> #   `ground-speed` <dbl>, heading <dbl>, `height-above-msl` <dbl>,
+#> #   `location-error-numerical` <dbl>, `manually-marked-outlier` <lgl>,
+#> #   `vertical-error-numerical` <dbl>, `sensor-type` <chr>,
+#> #   `individual-taxon-canonical-name` <chr>, `tag-local-identifier` <chr>,
+#> #   `individual-local-identifier` <chr>, `study-name` <chr>
 ```
 
-The data frame contains all GPS records, even though the actual data were split over [multiple CSV zipped files](https://zenodo.org/records/10053702#files-heading). `read_resource()` assigned the column names and types based on the Table Schema that was defined for that resource, not the headers of the CSV file.
+The data frame contains all GPS records, even though the actual data were split over [multiple zipped CSV files](https://zenodo.org/records/10053702#files-heading). `read_resource()` assigned the column names and types based on the Table Schema that was defined for that resource, not the headers of the CSV file.
 
 You can also read data from a local (e.g. downloaded) Data Package. In fact, there is one included in frictionless, let's read that one from disk:
 
 
 ``` r
-local_package <- read_package(
-  system.file("extdata", "v1", "datapackage.json", package = "frictionless")
-)
+example_package <- example_package()
 
-local_package
-#> A Data Package (version 1.0) with 3 resources:
+example_package
+#> A Data Package (version 2.0) with 3 resources:
 #> • deployments
 #> • observations
 #> • media
 #> Use `unclass()` to print the Data Package as a list.
 
-read_resource(local_package, "media")
+read_resource(example_package, "media")
 #> # A tibble: 3 × 5
-#>   media_id                      deployment_id observation_id timestamp file_path
-#>   <chr>                         <chr>         <chr>          <chr>     <chr>    
-#> 1 aed5fa71-3ed4-4284-a6ba-3550… 1             1-1            2020-09-… https://…
-#> 2 da81a501-8236-4cbd-aa95-4bc4… 1             1-1            2020-09-… https://…
-#> 3 0ba57608-3cf1-49d6-a5a2-fe68… 1             1-1            2020-09-… https://…
+#>   media_id                             deployment_id observation_id
+#>   <chr>                                <chr>         <chr>         
+#> 1 aed5fa71-3ed4-4284-a6ba-3550d1a4de8d 1             1-1           
+#> 2 da81a501-8236-4cbd-aa95-4bc4b10a05df 1             1-1           
+#> 3 0ba57608-3cf1-49d6-a5a2-fe680851024d 1             1-1           
+#>   timestamp                 file_path                                    
+#>   <chr>                     <chr>                                        
+#> 1 2020-09-28 02:14:59+02:00 https://multimedia.agouti.eu/assets/aed5fa71…
+#> 2 2020-09-28 02:15:00+02:00 https://multimedia.agouti.eu/assets/da81a501…
+#> 3 2020-09-28 02:15:01+02:00 https://multimedia.agouti.eu/assets/0ba57608…
 ```
 
 Data from the `media` was not stored in a CSV file, but directly in the `data` property of that resource in `datapackage.json`. `read_resource()` will automatically detect where to read data from.
@@ -185,7 +200,7 @@ You can chain most frictionless functions together using pipes (`|>`), which imp
 
 ``` r
 my_package
-#> A Data Package (version 1.0) with 1 resource:
+#> A Data Package (version 2.0) with 1 resource:
 #> • iris
 #> Use `unclass()` to print the Data Package as a list.
 ```
@@ -199,8 +214,9 @@ iris_schema <-
   schema("iris")
 
 str(iris_schema)
-#> List of 1
-#>  $ fields:List of 5
+#> List of 2
+#>  $ $schema: chr "https://datapackage.org/profiles/2.0/tableschema.json"
+#>  $ fields :List of 5
 #>   ..$ :List of 2
 #>   .. ..$ name: chr "Sepal.Length"
 #>   .. ..$ type: chr "number"
@@ -230,8 +246,9 @@ You can also create a schema from a data frame, using `create_schema()`:
 iris_schema <- create_schema(iris)
 
 str(iris_schema)
-#> List of 1
-#>  $ fields:List of 5
+#> List of 2
+#>  $ $schema: chr "https://datapackage.org/profiles/2.0/tableschema.json"
+#>  $ fields :List of 5
 #>   ..$ :List of 2
 #>   .. ..$ name: chr "Sepal.Length"
 #>   .. ..$ type: chr "number"
@@ -288,8 +305,9 @@ iris_schema$fields <- purrr::imap(
 )
 
 str(iris_schema)
-#> List of 1
-#>  $ fields:List of 5
+#> List of 2
+#>  $ $schema: chr "https://datapackage.org/profiles/2.0/tableschema.json"
+#>  $ fields :List of 5
 #>   ..$ :List of 3
 #>   .. ..$ name       : chr "Sepal.Length"
 #>   .. ..$ type       : chr "number"
@@ -338,8 +356,8 @@ If you already have your data stored as CSV or TSV files and you want to include
 
 ``` r
 # Two TSV files with the same structure
-path_1 <- system.file("extdata", "v1", "observations_1.tsv", package = "frictionless")
-path_2 <- system.file("extdata", "v1", "observations_2.tsv", package = "frictionless")
+path_1 <- system.file("extdata", "v2", "observations_1.tsv", package = "frictionless")
+path_2 <- system.file("extdata", "v2", "observations_2.tsv", package = "frictionless")
 
 # Add both TSV files as a single resource
 my_package <-
@@ -376,12 +394,13 @@ Now that you have created your Data Package, you can write it to a directory of 
 write_package(my_package, "my_directory")
 ```
 
-The directory will contain four files: the descriptor `datapackage.json`, one CSV file containing the data for the resource `iris` and two TSV files containing the data for the resource `observations`.
+The directory will now contain four files: the descriptor `datapackage.json`, one CSV file containing the data for the resource `iris` and two TSV files containing the data for the resource `observations`.
 
 
 ``` r
 list.files("my_directory")
-#> [1] "datapackage.json"   "iris.csv"           "observations_1.tsv" "observations_2.tsv"
+#> [1] "datapackage.json"   "iris.csv"           "observations_1.tsv"
+#> [4] "observations_2.tsv"
 ```
 
 

--- a/vignettes/frictionless.Rmd
+++ b/vignettes/frictionless.Rmd
@@ -12,7 +12,7 @@ vignette: >
 
 ## What is a Data Package?
 
-A [Data Package](https://specs.frictionlessdata.io/data-package/) is a simple container format to describe and package a collection of (tabular) data. It is typically used to publish FAIR and open datasets. In this tutorial we will show you how to read, create, edit and write Data Packages with the **frictionless**.
+A [Data Package](https://datapackage.org/) is a simple container format to describe and package a collection of (tabular) data. It is typically used to publish FAIR and open datasets. In this tutorial we will show you how to read, create, edit and write Data Packages with the **frictionless**.
 
 ## Read a Data Package
 
@@ -351,7 +351,7 @@ my_package <-
   )
 ```
 
-Your Data Package now contains 2 resources, but you can add metadata properties as well (see the [Data Package documentation](https://specs.frictionlessdata.io/data-package/#metadata) for an overview). Since it is a list, you can use `append()` to insert properties at the desired place. Let's add `name` as first and `title` as second property:
+Your Data Package now contains 2 resources, but you can add metadata properties as well (see the [Data Package documentation](https://datapackage.org/standard/data-package/#properties) for an overview). Since it is a list, you can use `append()` to insert properties at the desired place. Let's add `name` as first and `title` as second property:
 
 
 ``` r

--- a/vignettes/frictionless.Rmd.orig
+++ b/vignettes/frictionless.Rmd.orig
@@ -58,18 +58,16 @@ gps <- read_resource(package, "gps")
 gps
 ```
 
-The data frame contains all GPS records, even though the actual data were split over [multiple CSV zipped files](https://zenodo.org/records/10053702#files-heading). `read_resource()` assigned the column names and types based on the Table Schema that was defined for that resource, not the headers of the CSV file.
+The data frame contains all GPS records, even though the actual data were split over [multiple zipped CSV files](https://zenodo.org/records/10053702#files-heading). `read_resource()` assigned the column names and types based on the Table Schema that was defined for that resource, not the headers of the CSV file.
 
 You can also read data from a local (e.g. downloaded) Data Package. In fact, there is one included in frictionless, let's read that one from disk:
 
 ```{r}
-local_package <- read_package(
-  system.file("extdata", "v1", "datapackage.json", package = "frictionless")
-)
+example_package <- example_package()
 
-local_package
+example_package
 
-read_resource(local_package, "media")
+read_resource(example_package, "media")
 ```
 
 Data from the `media` was not stored in a CSV file, but directly in the `data` property of that resource in `datapackage.json`. `read_resource()` will automatically detect where to read data from.
@@ -170,8 +168,8 @@ If you already have your data stored as CSV or TSV files and you want to include
 
 ```{r}
 # Two TSV files with the same structure
-path_1 <- system.file("extdata", "v1", "observations_1.tsv", package = "frictionless")
-path_2 <- system.file("extdata", "v1", "observations_2.tsv", package = "frictionless")
+path_1 <- system.file("extdata", "v2", "observations_1.tsv", package = "frictionless")
+path_2 <- system.file("extdata", "v2", "observations_2.tsv", package = "frictionless")
 
 # Add both TSV files as a single resource
 my_package <-
@@ -206,7 +204,7 @@ Now that you have created your Data Package, you can write it to a directory of 
 write_package(my_package, "my_directory")
 ```
 
-The directory will contain four files: the descriptor `datapackage.json`, one CSV file containing the data for the resource `iris` and two TSV files containing the data for the resource `observations`.
+The directory will now contain four files: the descriptor `datapackage.json`, one CSV file containing the data for the resource `iris` and two TSV files containing the data for the resource `observations`.
 
 ```{r}
 list.files("my_directory")

--- a/vignettes/frictionless.Rmd.orig
+++ b/vignettes/frictionless.Rmd.orig
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 
 ## What is a Data Package?
 
-A [Data Package](https://specs.frictionlessdata.io/data-package/) is a simple container format to describe and package a collection of (tabular) data. It is typically used to publish FAIR and open datasets. In this tutorial we will show you how to read, create, edit and write Data Packages with the **frictionless**.
+A [Data Package](https://datapackage.org/) is a simple container format to describe and package a collection of (tabular) data. It is typically used to publish FAIR and open datasets. In this tutorial we will show you how to read, create, edit and write Data Packages with the **frictionless**.
 
 ## Read a Data Package
 
@@ -183,7 +183,7 @@ my_package <-
   )
 ```
 
-Your Data Package now contains 2 resources, but you can add metadata properties as well (see the [Data Package documentation](https://specs.frictionlessdata.io/data-package/#metadata) for an overview). Since it is a list, you can use `append()` to insert properties at the desired place. Let's add `name` as first and `title` as second property:
+Your Data Package now contains 2 resources, but you can add metadata properties as well (see the [Data Package documentation](https://datapackage.org/standard/data-package/#properties) for an overview). Since it is a list, you can use `append()` to insert properties at the desired place. Let's add `name` as first and `title` as second property:
 
 ```{r}
 my_package <- append(my_package, c(name = "my_package"), after = 0)

--- a/vignettes/table-dialect.Rmd
+++ b/vignettes/table-dialect.Rmd
@@ -48,7 +48,11 @@ frictionless does not support direct manipulation of the dialect. `add_resource(
 
 ### $schema
 
-[`$schema`](https://datapackage.org/standard/table-dialect/#dollar-schema) indicates what version of the Table Dialect standard is used (v1 if undefined). It is ignored by `read_resource()`, since all dialect properties supported by frictionless are the same in v1 and v2. `add_resource()` does not define a dialect (except for a non-default `delimiter`) and does set not `$schema` and thus creates a v1 dialect. `upgrade_package()` leaves dialect as is for all resources.
+[`$schema`](https://datapackage.org/standard/table-dialect/#dollar-schema) indicates what `version()` of the Table Dialect standard is used (v1 if undefined).
+
+- `read_resource()` ignores it, since all dialect properties supported by frictionless are the same in v1 and v2.
+- `add_resource()` does _not_ set `$schema` to the recommended v2 value (`"https://datapackage.org/profiles/2.0/tabledialect.json"`), because it typically does not define a dialect and therefore `$schema`. It thus creates (default to) a v1 dialect.
+- `upgrade_package()` leaves dialect as is for all resources.
 
 ### header
 

--- a/vignettes/table-dialect.Rmd
+++ b/vignettes/table-dialect.Rmd
@@ -46,6 +46,22 @@ frictionless does not support direct manipulation of the dialect. `add_resource(
 
 ## Properties implementation
 
+### $schema
+
+### header
+
+[`header`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to `true`. It is passed as `trim_ws = 1` (or `0`) in `readr::read_delim()`.
+
+<!-- ### headerRows -->
+
+<!-- ### headerJoin -->
+
+<!-- ## commentRows -->
+
+### commentChar
+
+[`commentChar`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to undefined. It is passed to `comment` in `readr::read_delim()`.
+
 ### delimiter
 
 [`delimiter`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to `","`. It is passed to `delim` in `readr::read_delim()`. `add_resource()` does not set `delimiter`, unless provided in `delim` and different from the default `","`:
@@ -87,13 +103,6 @@ package$resources[[2]]$dialect$delimiter
 
 [`skipInitialSpace`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to `false`. It is passed to `trim_ws` in `readr::read_delim()`.
 
-### header
-
-[`header`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to `true`. It is passed as `trim_ws = 1` (or `0`) in `readr::read_delim()`.
-
-### commentChar
-
-[`commentChar`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to undefined. It is passed to `comment` in `readr::read_delim()`.
 
 ### caseSensitiveHeader
 

--- a/vignettes/table-dialect.Rmd
+++ b/vignettes/table-dialect.Rmd
@@ -23,7 +23,7 @@ In this document we use the terms "package" for Data Package, "resource" for Dat
 
 ## General implementation
 
-frictionless supports most dialect properties to read [Tabular Data Resources](https://datapackage.org/standard/data-resource/#tabular), but only those designed for [delimited formats](https://datapackage.org/standard/table-dialect/#delimited) (not structured, spreadsheet, database formats). Dialect manipulation is limited to setting a `delimiter`. When writing resources, it (mainly) makes uses of default dialect properties, removing the necessity to define them.
+frictionless supports most dialect properties to read [Tabular Data Resources](https://datapackage.org/standard/data-resource/#tabular), but only those designed for [delimited formats](https://datapackage.org/standard/table-dialect/#delimited) (not structured, spreadsheet, database formats). Dialect manipulation is limited to setting a `delimiter`. When writing resources, it (mainly) makes use of default dialect properties, removing the necessity to define them.
 
 ### Read
 

--- a/vignettes/table-dialect.Rmd
+++ b/vignettes/table-dialect.Rmd
@@ -50,7 +50,7 @@ frictionless does not support direct manipulation of the dialect. `add_resource(
 
 ### header
 
-[`header`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to `true`. It is passed as `trim_ws = 1` (or `0`) in `readr::read_delim()`.
+[`header`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to `true`. It is passed as `skip = 1` (or `0` for `false`) in `readr::read_delim()`, ignoring the header. Field names in `schema` are used instead.
 
 <!-- ### headerRows -->
 

--- a/vignettes/table-dialect.Rmd
+++ b/vignettes/table-dialect.Rmd
@@ -48,7 +48,7 @@ frictionless does not support direct manipulation of the dialect. `add_resource(
 
 ### $schema
 
-[`$schema`](https://datapackage.org/standard/table-dialect/#dollar-schema) indicates what version of the Table Dialect standard is used (v1 if undefined). **All dialect properties supported by frictionless are the same in v1 and v2**. `$schema` is therefore ignored by `read_resource()`. While `add_resource()` creates a v2 resource, it typically does not define a dialect, except to declare a non-default `delimiter` (same in v1 and v2). It therefore does _not_ set `$schema` to `"https://datapackage.org/profiles/2.0/tabledialect.json"` (the recommended v2 value). Neither does `upgrade_package()` which leaves the dialect as is for all resources.
+[`$schema`](https://datapackage.org/standard/table-dialect/#dollar-schema) indicates what version of the Table Dialect standard is used (v1 if undefined). It is ignored by `read_resource()`, since all dialect properties supported by frictionless are the same in v1 and v2. `add_resource()` does not define a dialect (except for a non-default `delimiter`) and does set not `$schema` and thus creates a v1 dialect. `upgrade_package()` leaves dialect as is for all resources.
 
 ### header
 

--- a/vignettes/table-dialect.Rmd
+++ b/vignettes/table-dialect.Rmd
@@ -23,7 +23,7 @@ In this document we use the terms "package" for Data Package, "resource" for Dat
 
 ## General implementation
 
-frictionless supports most dialect properties designed for [delimited formats](https://datapackage.org/standard/table-dialect/#delimited) to read [Tabular Data Resources](https://datapackage.org/standard/data-resource/#tabular). Dialect manipulation is limited to setting a `delimiter`. When writing resources, it (mainly) makes uses of default dialect properties, removing the necessity to define them.
+frictionless supports most dialect properties to read [Tabular Data Resources](https://datapackage.org/standard/data-resource/#tabular), but only those designed for [delimited formats](https://datapackage.org/standard/table-dialect/#delimited) (not structured, spreadsheet, database formats). Dialect manipulation is limited to setting a `delimiter`. When writing resources, it (mainly) makes uses of default dialect properties, removing the necessity to define them.
 
 ### Read
 
@@ -54,11 +54,22 @@ frictionless does not support direct manipulation of the dialect. `add_resource(
 
 [`header`](https://datapackage.org/standard/table-dialect/#header) is used by `read_resource()` and defaults to `true`. It is passed as `skip = 1` (or `0` for `false`) in `readr::read_delim()`, ignoring the header. Field names in `schema` are used instead.
 
-<!-- ### headerRows -->
+### headerRows
 
-<!-- ### headerJoin -->
 
-<!-- ## commentRows -->
+[`headerRows`](https://datapackage.org/standard/table-dialect/#headerRows) is ignored by `read_resource()`.
+
+### headerJoin
+
+<!-- Not spec compliant -->
+
+[`headerJoin`](https://datapackage.org/standard/table-dialect/#headerJoin) is ignored by `read_resource()`.
+
+### commentRows
+
+<!-- Not spec compliant -->
+
+[`commentRows`](https://datapackage.org/standard/table-dialect/#headerJoin) is ignored by `read_resource()`.
 
 ### commentChar
 

--- a/vignettes/table-dialect.Rmd
+++ b/vignettes/table-dialect.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-[Table Dialect](https://specs.frictionlessdata.io/csv-dialect/) (previously called CSV dialect) is a simple format to describe the dialect of a tabular data file, including its delimiter, header rows, escape characters, etc.
+[Table Dialect](https://datapackage.org/standard/table-dialect/) is a simple format to describe the dialect of a tabular data file, including its delimiter, header rows, escape characters, etc.
 
 ::: {.callout-note}
 In this document we use the terms "package" for Data Package, "resource" for Data Resource, "dialect" for Table Dialect, and "schema" for Table Schema.
@@ -23,7 +23,7 @@ In this document we use the terms "package" for Data Package, "resource" for Dat
 
 ## General implementation
 
-frictionless supports most dialect properties to read [Tabular Data Resources](https://datapackage.org/standard/data-resource/#tabular). Dialect manipulation is limited to setting a `delimiter`. When writing resources, it (mainly) makes uses of default dialect properties, removing the necessity to define them.
+frictionless supports most dialect properties designed for [delimited formats](https://datapackage.org/standard/table-dialect/#delimited) to read [Tabular Data Resources](https://datapackage.org/standard/data-resource/#tabular). Dialect manipulation is limited to setting a `delimiter`. When writing resources, it (mainly) makes uses of default dialect properties, removing the necessity to define them.
 
 ### Read
 
@@ -38,7 +38,7 @@ frictionless supports most dialect properties to read [Tabular Data Resources](h
 
 ### Manipulate
 
-frictionless does not support direct manipulation of the dialect. `add_resource()` allows to set one property (`dialect$delimiter`) when data are provided as a file, all other properties are assumed to be the default.
+frictionless does not support direct manipulation of the dialect. `add_resource()` allows to set one property (`delimiter`) when data are provided as a file, all other properties are assumed to be the default.
 
 ### Write
 
@@ -48,9 +48,11 @@ frictionless does not support direct manipulation of the dialect. `add_resource(
 
 ### $schema
 
+[`$schema`](https://datapackage.org/standard/table-dialect/#dollar-schema) indicates what version of the Table Dialect standard is used (v1 if undefined). **All dialect properties supported by frictionless are the same in v1 and v2**. `$schema` is therefore ignored by `read_resource()`. While `add_resource()` creates a v2 resource, it typically does not define a dialect, except to declare a non-default `delimiter` (same in v1 and v2). It therefore does _not_ set `$schema` to `"https://datapackage.org/profiles/2.0/tabledialect.json"` (the recommended v2 value). Neither does `upgrade_package()` which leaves the dialect as is for all resources.
+
 ### header
 
-[`header`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to `true`. It is passed as `skip = 1` (or `0` for `false`) in `readr::read_delim()`, ignoring the header. Field names in `schema` are used instead.
+[`header`](https://datapackage.org/standard/table-dialect/#header) is used by `read_resource()` and defaults to `true`. It is passed as `skip = 1` (or `0` for `false`) in `readr::read_delim()`, ignoring the header. Field names in `schema` are used instead.
 
 <!-- ### headerRows -->
 
@@ -60,19 +62,19 @@ frictionless does not support direct manipulation of the dialect. `add_resource(
 
 ### commentChar
 
-[`commentChar`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to undefined. It is passed to `comment` in `readr::read_delim()`.
+[`commentChar`](https://datapackage.org/standard/table-dialect/#commentChar) is used by `read_resource()` and defaults to undefined. It is passed to `comment` in `readr::read_delim()`.
 
 ### delimiter
 
-[`delimiter`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to `","`. It is passed to `delim` in `readr::read_delim()`. `add_resource()` does not set `delimiter`, unless provided in `delim` and different from the default `","`:
+[`delimiter`](https://datapackage.org/standard/table-dialect/#delimiter) is used by `read_resource()` and defaults to `","`. It is passed to `delim` in `readr::read_delim()`. `add_resource()` does not set `delimiter`, unless provided in `delim` and different from the default `","`:
 
 ```{r}
 library(frictionless)
 package <- example_package()
 
-path <- system.file("extdata", "v1", "observations_1.tsv", package = "frictionless")
+path <- system.file("extdata", "v2", "observations_1.tsv", package = "frictionless")
 package <- add_resource(package, "observations", data = path, delim = "\t", replace = TRUE)
-package$resources[[2]]$dialect$delimiter
+resource(package, "observations")$dialect$delimiter
 ```
 
 ### lineTerminator
@@ -81,15 +83,15 @@ package$resources[[2]]$dialect$delimiter
 
 ### quoteChar
 
-[`quoteChar`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to `"`. It is passed to `quote` in `readr::read_delim()`.
+[`quoteChar`](https://datapackage.org/standard/table-dialect/#quoteChar) is used by `read_resource()` and defaults to `"`. It is passed to `quote` in `readr::read_delim()`.
 
 ### doubleQuote
 
-[`doubleQuote`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to `true`, but can be overruled by `escapeChar`. It is passed to `escape_double` in `readr::read_delim()`.
+[`doubleQuote`](https://datapackage.org/standard/table-dialect/#doubleQuote) is used by `read_resource()` and defaults to `true`, but can be overruled by `escapeChar`. It is passed to `escape_double` in `readr::read_delim()`.
 
 ### escapeChar
 
-[`escapeChar`](https://specs.frictionlessdata.io/csv-dialect/#specification) is ignored by `read_resource()` unless it is `"\\"`. It is passed as `escape_backslash = TRUE` and `escape_double = FALSE` in `readr::read_delim()`.
+[`escapeChar`](https://datapackage.org/standard/table-dialect/#escapeChar) is ignored by `read_resource()` unless it is `"\\"`. It is passed as `escape_backslash = TRUE` and `escape_double = FALSE` in `readr::read_delim()`.
 
 ::: {.callout-warning}
 `escapeChar` and `doubleQuote` are mutually exclusive, so you cannot escape with `\"` and `""` in the same file.
@@ -97,17 +99,8 @@ package$resources[[2]]$dialect$delimiter
 
 ### nullSequence
 
-[`nullSequence`](https://specs.frictionlessdata.io/csv-dialect/#specification) is ignored by `read_resource()`. Provide as `missingValues` in the schema instead (see `vignette("table-schema")`).
+[`nullSequence`](https://datapackage.org/standard/table-dialect/#nullSequence) is ignored by `read_resource()`. Provide as `missingValues` in the schema instead (see `vignette("table-schema")`).
 
 ### skipInitialSpace
 
-[`skipInitialSpace`](https://specs.frictionlessdata.io/csv-dialect/#specification) is used by `read_resource()` and defaults to `false`. It is passed to `trim_ws` in `readr::read_delim()`.
-
-
-### caseSensitiveHeader
-
-[`caseSensitiveHeader`](https://specs.frictionlessdata.io/csv-dialect/#specification) is ignored by `read_resource()`.
-
-### csvddfVersion
-
-[`csvddfVersion`](https://specs.frictionlessdata.io/csv-dialect/#specification) is ignored by `read_resource()`.
+[`skipInitialSpace`](https://datapackage.org/standard/table-dialect/#skipInitialSpace) is used by `read_resource()` and defaults to `false`. It is passed to `trim_ws` in `readr::read_delim()`.

--- a/vignettes/table-dialect.Rmd
+++ b/vignettes/table-dialect.Rmd
@@ -56,20 +56,15 @@ frictionless does not support direct manipulation of the dialect. `add_resource(
 
 ### headerRows
 
-
-[`headerRows`](https://datapackage.org/standard/table-dialect/#headerRows) is ignored by `read_resource()`.
+[`headerRows`](https://datapackage.org/standard/table-dialect/#headerRows) is **not supported** by `read_resource()`.
 
 ### headerJoin
 
-<!-- Not spec compliant -->
-
-[`headerJoin`](https://datapackage.org/standard/table-dialect/#headerJoin) is ignored by `read_resource()`.
+[`headerJoin`](https://datapackage.org/standard/table-dialect/#headerJoin) is **not supported** by `read_resource()`.
 
 ### commentRows
 
-<!-- Not spec compliant -->
-
-[`commentRows`](https://datapackage.org/standard/table-dialect/#headerJoin) is ignored by `read_resource()`.
+[`commentRows`](https://datapackage.org/standard/table-dialect/#commentRows) is **not supported** by `read_resource()`.
 
 ### commentChar
 
@@ -90,7 +85,7 @@ resource(package, "observations")$dialect$delimiter
 
 ### lineTerminator
 
-[`lineTerminator`](https://datapackage.org/standard/table-dialect/#lineTerminator) is ignored by `read_resource()`. It relies on `readr::read_delim()` instead, which interprets line terminator `LF` and `CRLF` automatically and does not support `CR` (used by Classic Mac OS, final release 2001).
+[`lineTerminator`](https://datapackage.org/standard/table-dialect/#lineTerminator) is **not supported** by `read_resource()`. It relies on `readr::read_delim()` instead, which interprets line terminator `LF` and `CRLF` automatically and does not support `CR` (used by Classic Mac OS, final release 2001).
 
 ### quoteChar
 
@@ -102,7 +97,7 @@ resource(package, "observations")$dialect$delimiter
 
 ### escapeChar
 
-[`escapeChar`](https://datapackage.org/standard/table-dialect/#escapeChar) is ignored by `read_resource()` unless it is `"\\"`. It is passed as `escape_backslash = TRUE` and `escape_double = FALSE` in `readr::read_delim()`.
+[`escapeChar`](https://datapackage.org/standard/table-dialect/#escapeChar) is **not supported** by `read_resource()` unless it is `"\\"`. It is passed as `escape_backslash = TRUE` and `escape_double = FALSE` in `readr::read_delim()`.
 
 ::: {.callout-warning}
 `escapeChar` and `doubleQuote` are mutually exclusive, so you cannot escape with `\"` and `""` in the same file.
@@ -110,7 +105,7 @@ resource(package, "observations")$dialect$delimiter
 
 ### nullSequence
 
-[`nullSequence`](https://datapackage.org/standard/table-dialect/#nullSequence) is ignored by `read_resource()`. Provide as `missingValues` in the schema instead (see `vignette("table-schema")`).
+[`nullSequence`](https://datapackage.org/standard/table-dialect/#nullSequence) is **not supported** by `read_resource()`. Provide as `missingValues` in the schema instead (see `vignette("table-schema")`).
 
 ### skipInitialSpace
 

--- a/vignettes/table-schema.Rmd
+++ b/vignettes/table-schema.Rmd
@@ -240,8 +240,8 @@ any other type | `any`
 
 [`boolean`](https://datapackage.org/standard/table-schema/#boolean) is interpreted as `logical`.
 
-- `trueValues` that are non-default are **not supported**.
-- `falseValues` that are non-default are **not supported**.
+- `trueValues` is **not supported**, except for the default values (`"true"`, `"True"`, `"TRUE"`, `"1"`).
+- `falseValues` is **not supported**, except for the default values (`"false"`, `"False"`, `"FALSE"`, `"0"`).
 
 ### object
 

--- a/vignettes/table-schema.Rmd
+++ b/vignettes/table-schema.Rmd
@@ -218,8 +218,8 @@ any other type | `any`
 
 [`boolean`](https://specs.frictionlessdata.io/table-schema/#boolean) is interpreted as `logical`.
 
-- `trueValues` that are not defaults are not supported.
-- `falseValues` that are not defaults are not supported.
+- Non-default `trueValues` are not supported.
+- Non-default `falseValues` are not supported.
 
 ### object
 

--- a/vignettes/table-schema.Rmd
+++ b/vignettes/table-schema.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-[Table Schema](https://specs.frictionlessdata.io/table-schema/) is a simple format to describe tabular data, including field names, types, constraints, missing values, foreign keys, etc.
+[Table Schema](https://datapackage.org/standard/table-schema/) is a simple format to describe tabular data, including field names, types, constraints, missing values, foreign keys, etc.
 
 ::: {.callout-note}
 In this document we use the terms "package" for Data Package, "resource" for Data Resource, "dialect" for Table Dialect, and "schema" for Table Schema.
@@ -101,35 +101,37 @@ package <- add_resource(
 
 ### fields
 
-[`fields`](https://specs.frictionlessdata.io/table-schema/#field-descriptors) is required. It is used by `read_resource()` to parse the names and data types of the columns in a tabular data file. `create_schema()` sets `fields` based on information in a data frame. See [Field properties implementation](#field-properties-implementation) for details.
+[`fields`](https://datapackage.org/standard/table-schema/#fields) is required. It is used by `read_resource()` to parse the names and data types of the columns in a tabular data file. `create_schema()` sets `fields` based on information in a data frame. See [Field properties implementation](#field-properties-implementation) for details.
 
-<!-- ### $schema -->
+### fieldsMatch
 
-<!-- ### fieldMatch -->
+[`fieldsMatch`](https://datapackage.org/standard/table-schema/#fieldsMatch) is **not supported** by `read_resource()`. It expects the default (`exact`).
 
 ### missingValues
 
-[`missingValues`](https://specs.frictionlessdata.io/table-schema/#missing-values) is used by `read_resource()` and defaults to `""`. It is passed to `na` in `readr::read_delim()`. `create_schema()` does not set `missingValues`. `write_package()` converts `NA` values to `""` when writing a data frame to a CSV file. Since this is the default, no `missingValues` property is set.
+[`missingValues`](https://datapackage.org/standard/table-schema/#missingValues) is used by `read_resource()` and defaults to `""`. It is passed to `na` in `readr::read_delim()`. If provided as labelled values, the `value` is extracted and `label` ignored. `create_schema()` does not set `missingValues`. `write_package()` converts `NA` values to `""` when writing a data frame to a CSV file. Since this is the default, no `missingValues` property is set.
 
 ### primaryKey
 
-[`primaryKey`](https://specs.frictionlessdata.io/table-schema/#primary-key) is ignored by `read_resource()` and not set by `create_schema()`.
+[`primaryKey`](https://datapackage.org/standard/table-schema/#primaryKey) is ignored by `read_resource()` and not set by `create_schema()`. `upgrade_package()` will convert single values to an array (for [backwards compatibility](https://datapackage.org/overview/changelog/#schemaprimarykey-updated)).
 
-<!-- ### uniqueKeys -->
+### uniqueKeys
+
+[`uniqueKeys`](https://datapackage.org/standard/table-schema/#uniqueKeys) is ignored by `read_resource()` and not set by `create_schema()`.
 
 ### foreignKeys
 
-[`foreignKeys`](https://specs.frictionlessdata.io/table-schema/#foreign-keys) is ignored by `read_resource()` and not set by `create_schema()`.
+[`foreignKeys`](https://datapackage.org/standard/table-schema/#foreignKeys) is ignored by `read_resource()` and not set by `create_schema()`. `upgrade_package()` will convert single values in `fields` to an array and remove `reference.resource` if it is self-referential (for [backwards compatibility](https://datapackage.org/overview/changelog/#schemaprimarykey-updated)).
 
 ## Field properties implementation
 
 ### name
 
-[`name`](https://specs.frictionlessdata.io/table-schema/#name) is used by `read_resource()` to assign a column name. The vector of names is passed as `col_names` to `readr::read_delim()`, ignoring names provided in the header of the data file. `create_schema()` uses the data frame column name to set `name`.
+[`name`](https://datapackage.org/standard/table-schema/#name) is used by `read_resource()` to assign a column name. The vector of names is passed as `col_names` to `readr::read_delim()`, ignoring names provided in the header of the data file. `create_schema()` uses the data frame column name to set `name`.
 
 ### type and format
 
-[`type`](https://specs.frictionlessdata.io/table-schema/#types-and-formats) and (for some types) [`format`](https://specs.frictionlessdata.io/table-schema/#types-and-formats) is used by `read_resource()` to understand the column type. The vector of types is passed as `col_types` to `readr::read_delim()`, which warns if there are parsing issues (inspect with `problems()`). `create_schema()` uses the data frame column type to set `type`. See [Field types implementation](#field-types-implementation) for details.
+[`type`](https://datapackage.org/standard/table-schema/#type-and-format) and (for some types) [`format`](https://datapackage.org/standard/table-schema/#type-and-format) is used by `read_resource()` to understand the column type. The vector of types is passed as `col_types` to `readr::read_delim()`, which warns if there are parsing issues (inspect with `problems()`). `create_schema()` uses the data frame column type to set `type`. See [Field types implementation](#field-types-implementation) for details.
 
 `read_resource()` interprets `type` as follows:
 
@@ -141,6 +143,7 @@ field type | column type
 [`boolean`](#boolean) | `logical`
 [`object`](#object) | `character`
 [`array`](#array) | `character`
+[`list`](#list) | `character`
 [`datetime`](#datetime) | `POSIXct`
 [`date`](#date) | `Date`
 [`time`](#time) | `hms::hms()`
@@ -172,107 +175,123 @@ any other type | `any`
 
 ### title
 
-[`title`](https://specs.frictionlessdata.io/table-schema/#title) is ignored by `read_resource()` and not set by `create_schema()`.
+[`title`](https://datapackage.org/standard/table-schema/#title) is ignored by `read_resource()` and not set by `create_schema()`.
 
 ### description
 
-[`description`](https://specs.frictionlessdata.io/table-schema/#description) is ignored by `read_resource()` and not set by `create_schema()`.
+[`description`](https://datapackage.org/standard/table-schema/#description) is ignored by `read_resource()` and not set by `create_schema()`.
 
 ### example
 
-[`example`](https://specs.frictionlessdata.io/table-schema/#example) is ignored by `read_resource()` and not set by `create_schema()`.
+[`example`](https://datapackage.org/standard/table-schema/#example) is ignored by `read_resource()` and not set by `create_schema()`.
 
 ### constraints
 
-[`constraints`](https://specs.frictionlessdata.io/table-schema/#constraints) is ignored by `read_resource()` and not set by `create_schema()`, except for `constraints$enum`. `read_resource()` uses it set the column type to `factor`, with `enum` values as factor levels. `create_schema()` does the reverse.
+[`constraints`](https://datapackage.org/standard/table-schema/#field-constraints) is ignored by `read_resource()` and not set by `create_schema()`, except for `constraints$enum`. `read_resource()` uses it set the column type to `factor`, with `enum` values as factor levels. `create_schema()` does the reverse.
 
-<!-- ### categories -->
+### categories
 
-<!-- ### categoriesOrdered -->
+[`categories`](https://datapackage.org/standard/table-schema/#categories) is ignored by `read_resource()` and not set by `create_schema()`.
 
-<!-- ### missingValues -->
+### categoriesOrdered
+
+[`categoriesOrdered`](https://datapackage.org/standard/table-schema/#categoriesOrdered) is ignored by `read_resource()` and not set by `create_schema()`.
+
+### missingValues
+
+[`missingValues](https://datapackage.org/standard/table-schema/#field-missingValues) at field-level is **not supported** by `read_resource()` and not set by `create_schema()`. Provide as `missingValues` at schema-level instead.
 
 ### rdfType
 
-[`rdfType`](https://specs.frictionlessdata.io/table-schema/#rich-types) is ignored by `read_resource()` and not set by `create_schema()`.
+[`rdfType`](https://datapackage.org/standard/table-schema/#rdfType) is ignored by `read_resource()` and not set by `create_schema()`.
 
 ## Field types implementation
 
 ### string
 
-[`string`](https://specs.frictionlessdata.io/table-schema/#string) is interpreted as `character`. Or `factor` when `constraints$enum` is defined.
+[`string`](https://datapackage.org/standard/table-schema/#string) is interpreted as `character`. Or `factor` when `constraints$enum` is defined.
 
 - `format` is ignored.
 
 ### number
 
-[`number`](https://specs.frictionlessdata.io/table-schema/#number) is interpreted as `double`. Or `factor` when `constraints$enum` is defined.
+[`number`](https://datapackage.org/standard/table-schema/#number) is interpreted as `double`. Or `factor` when `constraints$enum` is defined.
 
 - `bareNumber` is supported. If `false`, whitespace and non-numeric characters are ignored.
 - `decimalChar` (`.` by default) is supported, but as a single value for all number fields. If different values are defined, the most occurring one is selected.
-- `groupChar` (undefined by default) is supported, but as a single value for all number fields. If different values are defined, the most occurring one is selected.
+- `groupChar` (undefined by default) is supported, but as a single value for all number and integer fields. If different values are defined (across numbers and integers), the most occurring one is selected.
+
+::: {.callout-warning}
+`decimalChar` and `groupChar` cannot have the same value, even if one is defined for a number and the other for an integer.
+:::
 
 ### integer
 
-[`integer`](https://specs.frictionlessdata.io/table-schema/#integer) is interpreted as `double` (to support big integers, + signs and `bareNumber`). Or `factor` when `constraints$enum` is defined.
+[`integer`](https://datapackage.org/standard/table-schema/#integer) is interpreted as `double` (to support big integers, + signs and `bareNumber`). Or `factor` when `constraints$enum` is defined.
 
+- `groupChar` (undefined by default) is supported, but as a single value for all number and integer fields. If different values are defined (across numbers and integers), the most occurring one is selected.
 - `bareNumber` is supported. If `false`, whitespace and non-numeric characters are ignored.
 
 ### boolean
 
-[`boolean`](https://specs.frictionlessdata.io/table-schema/#boolean) is interpreted as `logical`.
+[`boolean`](https://datapackage.org/standard/table-schema/#boolean) is interpreted as `logical`.
 
-- Non-default `trueValues` are not supported.
-- Non-default `falseValues` are not supported.
+- `trueValues` that are non-default are **not supported**.
+- `falseValues` that are non-default are **not supported**.
 
 ### object
 
-[`object`](https://specs.frictionlessdata.io/table-schema/#object) is interpreted as `character`
+[`object`](https://datapackage.org/standard/table-schema/#object) is interpreted as `character`.
 
 ### array
 
-[`array`](https://specs.frictionlessdata.io/table-schema/#array) is interpreted as `character`.
+[`array`](https://datapackage.org/standard/table-schema/#array) is interpreted as `character`.
 
-<!-- ### list -->
+### list
+
+[`list`](https://datapackage.org/standard/table-schema/#list) is interpreted as `character`.
+
+- `delimiter` is **not supported**.
+- `itemType` is **not supported**.
 
 ### datetime
 
 [`datetime`](https://datapackage.org/standard/table-schema/#datetime) is interpreted as `POSIXct`.
 
-- `format` is supported for the values `default` (ISO datetime, with optional milliseconds and timezone), `any` (ISO datetime) and the same patterns as for `date` and `time`. The value `%c` is not supported.
+- `format` is supported for the values `default` (ISO datetime, with optional milliseconds and timezone), `any` (ISO datetime) and the same patterns as for `date` and `time`. The value `%c` is **not supported**.
 
 ### date
 
-[`date`](https://specs.frictionlessdata.io/table-schema/#date) is interpreted as `Date`.
+[`date`](https://datapackage.org/standard/table-schema/#date) is interpreted as `Date`.
 
-- `format` is supported for the values `default` (ISO date), `any` (guess `ymd`) and [Python/C strptime](https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior) patterns, such as `%a, %d %B %Y` for `Sat, 23 November 2013`. `%x` is interpreted as `%m/%d/%y`. The values `%j`, `%U`, `%w` and `%W` are not supported.
+- `format` is supported for the values `default` (ISO date), `any` (guess `ymd`) and [Python/C strptime](https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior) patterns, such as `%a, %d %B %Y` for `Sat, 23 November 2013`. `%x` is interpreted as `%m/%d/%y`. The values `%j`, `%U`, `%w` and `%W` are **not supported**.
 
 ### time
 
-[`time`](https://specs.frictionlessdata.io/table-schema/#time) is interpreted as `hms::hms()`.
+[`time`](https://datapackage.org/standard/table-schema/#time) is interpreted as `hms::hms()`.
 
 - `format` is supported for the values `default` (ISO time), `any` (guess `hms`) and [Python/C strptime](https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior) patterns, such as `%I%p%M:%S.%f%z` for `8AM30:00.300+0200`.
 
 ### year
 
-[`year`](https://specs.frictionlessdata.io/table-schema/#year) is interpreted as `Date` with month and day set to `01`.
+[`year`](https://datapackage.org/standard/table-schema/#year) is interpreted as `Date` with month and day set to `01`.
 
 ### yearmonth
 
-[`yearmonth`](https://specs.frictionlessdata.io/table-schema/#yearmonth) is interpreted as `Date` with day set to `01`.
+[`yearmonth`](https://datapackage.org/standard/table-schema/#yearmonth) is interpreted as `Date` with day set to `01`.
 
 ### duration
 
-[`duration`](https://specs.frictionlessdata.io/table-schema/#duration) is interpreted as `character`. You can parse these values with `lubridate::duration()`.
+[`duration`](https://datapackage.org/standard/table-schema/#duration) is interpreted as `character`. You can parse these values with `lubridate::duration()`.
 
 ### geopoint
 
-[`geopoint`](https://specs.frictionlessdata.io/table-schema/#geopoint) is interpreted as `character`.
+[`geopoint`](https://datapackage.org/standard/table-schema/#geopoint) is interpreted as `character`.
 
 ### geojson
 
-[`geojson`](https://specs.frictionlessdata.io/table-schema/#geojson) is interpreted as `character`.
+[`geojson`](https://datapackage.org/standard/table-schema/#geojson) is interpreted as `character`.
 
 ### any
 
-[`any`](https://specs.frictionlessdata.io/table-schema/#any) is interpreted as `character`
+[`any`](https://datapackage.org/standard/table-schema/#any) is interpreted as `character`

--- a/vignettes/table-schema.Rmd
+++ b/vignettes/table-schema.Rmd
@@ -70,7 +70,7 @@ levels(observations$life_stage)
 
 A schema is a list which you can manipulate, but frictionless does not provide functions to do that. Use `{purrr}` or base R instead (see `vignette("frictionless")`). You do not have to start a schema from scratch though: use `schema()` (see above) or `create_schema()` instead.
 
-`create_schema()` creates a schema from a data frame. **It will always create a schema following the [v2 specification](https://datapackage.org/standard/table-schema/).** It defines the `name`, `type` (and if a factor `constraints$enum`) for each field:
+`create_schema()` creates a schema from a data frame. **It always creates a schema following the [v2 specification](https://datapackage.org/standard/table-schema/).** It defines the `name`, `type` (and if a factor `constraints$enum`) for each field:
 
 ```{r}
 # Create a schema from the built-in dataset "iris"

--- a/vignettes/table-schema.Rmd
+++ b/vignettes/table-schema.Rmd
@@ -97,7 +97,11 @@ package <- add_resource(
 
 ### $schema
 
-[`$schema`](https://datapackage.org/standard/table-schema/#dollar-schema) indicates what version of the Table Schema standard is used (v1 if undefined). It is used by `read_resource()` to determine the version and **silently upgrade the schema from v1 to v2** before trying to read it. `create_scheme()` sets `$schema` to `"https://datapackage.org/profiles/2.0/tableschema.json"` (the recommended v2 value) and thus creates a v2 schema. `upgrade_package()` does the same for all resources of a package.
+[`$schema`](https://datapackage.org/standard/table-schema/#dollar-schema) indicates what `version()` of the Table Schema standard is used (v1 if undefined).
+
+- `read_resource()` uses it to detect if a schema is v1 and silently upgrade it to v2 before trying to read it.
+- `create_scheme()` sets `$schema` to the recommended v2 value ( (`"https://datapackage.org/profiles/2.0/tableschema.json"`) and thus creates a v2 schema.
+- `upgrade_package()` sets `$schema` to the recommended v2 value for all resources of a package.
 
 ### fields
 

--- a/vignettes/table-schema.Rmd
+++ b/vignettes/table-schema.Rmd
@@ -70,7 +70,7 @@ levels(observations$life_stage)
 
 A schema is a list which you can manipulate, but frictionless does not provide functions to do that. Use `{purrr}` or base R instead (see `vignette("frictionless")`). You do not have to start a schema from scratch though: use `schema()` (see above) or `create_schema()` instead.
 
-`create_schema()` creates a schema from a data frame and defines the `name`, `type` (and if a factor `constraints$enum`) for each field:
+`create_schema()` creates a schema from a data frame. **It will always create a schema following the [v2 specification](https://datapackage.org/standard/table-schema/).** It defines the `name`, `type` (and if a factor `constraints$enum`) for each field:
 
 ```{r}
 # Create a schema from the built-in dataset "iris"
@@ -94,6 +94,10 @@ package <- add_resource(
 `write_package()` writes a package to disk as a `datapackage.json` file. This file includes the metadata of all the resources, including the schema. To directly write a schema to disk, use `jsonlite::write_json()`.
 
 ## Schema properties implementation
+
+### $schema
+
+[`$schema`](https://datapackage.org/standard/table-schema/#dollar-schema) indicates what version of the Table Schema standard is used (v1 if undefined). It is used by `read_resource()` to determine the version and **silently upgrade the schema from v1 to v2** before trying to read it. `create_scheme()` sets `$schema` to `"https://datapackage.org/profiles/2.0/tableschema.json"` (the recommended v2 value) and thus creates a v2 schema. `upgrade_package()` does the same for all resources of a package.
 
 ### fields
 


### PR DESCRIPTION
Fix #332
Fix #215
Fix #226 (feature described in existing vignettes, not new one)

This PR:

- Updates any reference to specs.frictionlessdata.io to datapackage.org (unless v1 is specifically targetted)
- Updates the vignettes:
  - Describe support for newly introduced v2 properties
  - Describe backwards compatibility
- The documentation describes features that are still pending
  - `upgrade_package()` #317
  - list type support (pending)
  - integer groupChar #364 
  - labelled missing values #354
- Test updates:
  - Test `add_resource(replace = TRUE)` version support
  - Clarifies that `profile` is not removed by `upgrade_` when `$schema` is already v2
  - Tries to trick `version()` to interpret a custom profile as `1.0`

---

@sannegovaert you have read/reviewed the vignettes before. Would you care to review the updates and this PR?  