### PR TITLE
Support `type = list` (interpret as character)

### DIFF
--- a/R/check_schema.R
+++ b/R/check_schema.R
@@ -39,9 +39,9 @@ check_schema <- function(schema, data = NULL) {
   # Check fields have valid types (a mix of valid types and undefined is ok)
   field_types <- purrr::map_chr(fields, ~ .x$type %||% NA_character_)
   valid_types <- c(
-    "string", "number", "integer", "boolean", "object", "array", "date", "time",
-    "datetime", "year", "yearmonth", "duration", "geopoint", "geojson", "any",
-    NA_character_
+    "string", "number", "integer", "boolean", "object", "array", "list", "date",
+    "time", "datetime", "year", "yearmonth", "duration", "geopoint", "geojson",
+    "any", NA_character_
   )
   invalid_types <- setdiff(field_types, valid_types)
   if (length(invalid_types) > 0) {

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -53,6 +53,7 @@ field_to_col <- function(field) {
     "boolean" = readr::col_logical(),
     "object" = readr::col_character(),
     "array" = readr::col_character(),
+    "list" = readr::col_character(),
     "date" = col_date(format),
     "time" = col_time(format),
     "datetime" = col_datetime(format),

--- a/tests/testthat/data/type_other.csv
+++ b/tests/testthat/data/type_other.csv
@@ -1,2 +1,2 @@
-year,yearmonth,object,array,duration,geopoint,geojson,any,no_type
-2001,2001-03,"{'id': 1, 'name': 'foo'}","[1,2,3]",P3Y6M4DT12H30M5S,"90, 45","{'type': 'Feature', 'geometry': {'type': 'Point', 'coordinates': [125.6, 10.1]}, 'properties': {'name': 'Dinagat Islands'}}",true,true
+year,yearmonth,object,array,list,duration,geopoint,geojson,any,no_type
+2001,2001-03,"{'id': 1, 'name': 'foo'}","[1,2,3]","1,2,3",P3Y6M4DT12H30M5S,"90, 45","{'type': 'Feature', 'geometry': {'type': 'Point', 'coordinates': [125.6, 10.1]}, 'properties': {'name': 'Dinagat Islands'}}",true,true

--- a/tests/testthat/data/types.json
+++ b/tests/testthat/data/types.json
@@ -292,6 +292,10 @@
             "type": "array"
           },
           {
+            "name": "list",
+            "type": "list"
+          },
+          {
             "name": "duration",
             "type": "duration"
           },

--- a/tests/testthat/test-read_resource.R
+++ b/tests/testthat/test-read_resource.R
@@ -756,9 +756,10 @@ test_that("read_resource() handles other types", {
   expect_s3_class(resource$yearmonth, "Date")
   expect_identical(resource$yearmonth[1], as.Date("2001-03-01"))
 
-  # Interpret object, array, duration, geopoint, geojson as character
+  # Interpret object, array, list, duration, geopoint, geojson as character
   expect_type(resource$object, "character")
   expect_type(resource$array, "character")
+  expect_type(resource$list, "character")
   expect_type(resource$duration, "character")
   expect_type(resource$geopoint, "character")
   expect_type(resource$geojson, "character")


### PR DESCRIPTION
Easiest approach to #179. It supports users who have this type in their dataset rather than throwing an error for unrecognized type.

Leaving #170 for later full support.